### PR TITLE
Make the framework more compatible with illuminate components

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,8 +16,11 @@
          verbose="true"
 >
     <testsuites>
-        <testsuite name="Laravel Zero Test Suite">
+        <testsuite name="Integration">
             <directory suffix="Test.php">./tests/Integration</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
         </testsuite>
     </testsuites>
     <listeners>

--- a/src/Container.php
+++ b/src/Container.php
@@ -22,19 +22,67 @@ class Container extends BaseContainer implements LaravelApplication
     }
 
     /**
-     * {@inheritdoc}
+     * Get the base path of the Laravel installation.
+     *
+     * @param  string  $path
+     * @return string
      */
-    public function basePath()
+    public function basePath($path = '')
     {
-        return BASE_PATH;
+        return BASE_PATH.($path ? "/$path" : $path);
     }
 
     /**
-     * {@inheritdoc}
+     * Get the path to the application configuration files.
+     *
+     * @param  string  $path
+     * @return string
      */
-    public function databasePath()
+    public function configPath($path = '')
     {
-        return config('database.path') ?: (BASE_PATH.'/database');
+        return BASE_PATH.'/config'.($path ? "/$path" : $path);
+    }
+
+    /**
+     * Get the path to the database directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function databasePath($path = '')
+    {
+        return config('database.path') ?: (BASE_PATH.'/database'.($path ? "/$path" : $path));
+    }
+
+    /**
+     * Get the path to the language files.
+     *
+     * @return string
+     */
+    public function langPath()
+    {
+        return $this->resourcePath('lang');
+    }
+
+    /**
+     * Get the path to the resources directory.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function resourcePath($path = '')
+    {
+        return BASE_PATH.'/resources'.($path ? "/$path" : $path);
+    }
+
+    /**
+     * Get the path to the storage directory.
+     *
+     * @return string
+     */
+    public function storagePath()
+    {
+        return BASE_PATH.'/storage';
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -90,6 +90,32 @@ if (! function_exists('config_path')) {
     }
 }
 
+if (! function_exists('database_path')) {
+    /**
+     * Get the database path.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function database_path($path = '')
+    {
+        return app()->databasePath($path);
+    }
+}
+
+if (! function_exists('resource_path')) {
+    /**
+     * Get the path to the resources folder.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    function resource_path($path = '')
+    {
+        return app()->resourcePath($path);
+    }
+}
+
 if (! function_exists('storage_path')) {
     /**
      * Get the path to the storage folder.

--- a/tests/Integration/HelpersTest.php
+++ b/tests/Integration/HelpersTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Integration;
+
+use Tests\TestCase;
+
+class HelpersTest extends TestCase
+{
+    /** @test */
+    public function base_path_helper_function()
+    {
+        $this->assertEquals(BASE_PATH, base_path());
+        $this->assertEquals(BASE_PATH.'/some/directory', base_path('some/directory'));
+    }
+
+    /** @test */
+    public function config_path_helper_function()
+    {
+        $this->assertEquals(BASE_PATH.'/config', config_path());
+        $this->assertEquals(BASE_PATH.'/config/vendor', config_path('vendor'));
+        $this->assertEquals(BASE_PATH.'/config/custom.php', config_path('custom.php'));
+    }
+
+    /** @test */
+    public function database_path_helper_function()
+    {
+        $this->assertEquals(BASE_PATH.'/database', database_path());
+        $this->assertEquals(BASE_PATH.'/database/seeds', database_path('seeds'));
+        $this->assertEquals(BASE_PATH.'/database/seeds/DatabaseSeeder.php', database_path('seeds/DatabaseSeeder.php'));
+    }
+
+    /** @test */
+    public function resource_path_helper_function()
+    {
+        $this->assertEquals(BASE_PATH.'/resources', resource_path());
+        $this->assertEquals(BASE_PATH.'/resources/assets/js', resource_path('assets/js'));
+        $this->assertEquals(BASE_PATH.'/resources/assets/js/app.php', resource_path('assets/js/app.php'));
+    }
+
+    /** @test */
+    public function storage_path_helper_function()
+    {
+        $this->assertEquals(BASE_PATH.'/storage', storage_path());
+        $this->assertEquals(BASE_PATH.'/storage/logs', storage_path('logs'));
+        $this->assertEquals(BASE_PATH.'/storage/logs/laravel.log', storage_path('logs/laravel.log'));
+    }
+}

--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use LaravelZero\Framework\Container;
+
+class ContainerTest extends TestCase
+{
+    /** @test */
+    public function it_has_a_base_path_getter()
+    {
+        $container = new Container;
+
+        $this->assertEquals(BASE_PATH, $container->basePath());
+        $this->assertEquals(BASE_PATH.'/Unit', $container->basePath('Unit'));
+    }
+
+    /** @test */
+    public function it_has_a_config_path_getter()
+    {
+        $container = new Container;
+
+        $this->assertEquals(BASE_PATH.'/config', $container->configPath());
+        $this->assertEquals(BASE_PATH.'/config/custom.php', $container->configPath('custom.php'));
+    }
+
+    /** @test */
+    public function it_has_a_database_path_getter()
+    {
+        $container = new Container;
+
+        $this->assertEquals(BASE_PATH.'/database', $container->databasePath());
+        $this->assertEquals(BASE_PATH.'/database/migrations', $container->databasePath('migrations'));
+
+        // config settings take precedence
+        config(['database.path' => 'some/other/path']);
+        $this->assertEquals('some/other/path', $container->databasePath());
+    }
+
+    /** @test */
+    public function it_has_a_lang_path_getter()
+    {
+        $this->assertEquals(BASE_PATH.'/resources/lang', (new Container)->langPath());
+    }
+
+    /** @test */
+    public function it_has_a_storage_path_getter()
+    {
+        $this->assertEquals(BASE_PATH.'/storage', (new Container)->storagePath());
+    }
+
+    /** @test */
+    public function it_has_a_resource_path_getter()
+    {
+        $container = new Container;
+
+        $this->assertEquals(BASE_PATH.'/resources', $container->resourcePath());
+        $this->assertEquals(BASE_PATH.'/resources/assets/js', $container->resourcePath('assets/js'));
+        $this->assertEquals(BASE_PATH.'/resources/assets/js/app.php', $container->resourcePath('assets/js/app.php'));
+    }
+}


### PR DESCRIPTION
For illuminate components and other laravel packages to work nicely with laravel-zero we need this methods. Most make use of them to publish configuration, views and other assets.

Example from [illuminate/notifications](https://github.com/illuminate/notifications/blob/2ac99db8f358edc46a39e04ba0c8e3dec4a8f1dc/NotificationServiceProvider.php#L22)
```php
$this->publishes([
    __DIR__.'/resources/views' => $this->app->resourcePath('views/vendor/notifications'),
]);

# This currently reuslts in: 
# Error: Call to undefined method LaravelZero\Framework\Container::resourcePath()
```

Original laravel/fromework implementations (for reference):

* https://github.com/laravel/framework/blob/5.5/src/Illuminate/Foundation/Application.php#L316
* https://github.com/laravel/framework/blob/5.5/src/Illuminate/Foundation/helpers.php#L744
* https://github.com/laravel/framework/blob/5.5/src/Illuminate/Foundation/helpers.php#L844

Usage on popular packages:

* [Illuminate/Notifications/NotificationServiceProvider.php](https://github.com/illuminate/notifications/blob/2ac99db8f358edc46a39e04ba0c8e3dec4a8f1dc/NotificationServiceProvider.php#L22)
* [Spatie/Backup/BackupServiceProvider.php](https://github.com/spatie/laravel-backup/blob/8b1fdf898e8be7f5d3ba6738e5a60ad95c490f0c/src/BackupServiceProvider.php#L25)
* [Collective/Remote/RemoteServiceProvider.php](https://github.com/LaravelCollective/remote/blob/58108a50badd0548eb4c8ae1b4788169b47be628/src/RemoteServiceProvider.php#L33)