### PR TITLE
Extend zero's testcase in unit tests

### DIFF
--- a/tests/Unit/ContainerTest.php
+++ b/tests/Unit/ContainerTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit;
 
-use PHPUnit\Framework\TestCase;
 use LaravelZero\Framework\Container;
+use Tests\TestCase;
 
 class ContainerTest extends TestCase
 {


### PR DESCRIPTION
When running the tests I got an error that `BASE_PATH` was not defined. Turns out the unit tests extend PhpUnit's TestCase instead of Zero's own. This PR fixes that 🙂 