### PR TITLE
add detection if running as phar

### DIFF
--- a/src/Bootstrappers/Constants.php
+++ b/src/Bootstrappers/Constants.php
@@ -2,6 +2,8 @@
 
 namespace LaravelZero\Framework\Bootstrappers;
 
+use Phar;
+
 /**
  * This is the Laravel Zero Framework Bootstrapper Constants class.
  *
@@ -14,7 +16,11 @@ class Constants extends Bootstrapper
      */
     public function bootstrap(): void
     {
-        $basePath = defined('BASE_PATH') ? BASE_PATH : '';
+        if (!empty($pharPath = Phar::running(false))) {
+            $basePath = dirname($pharPath);
+        } else {
+            $basePath = defined('BASE_PATH') ? BASE_PATH : '';
+        }
 
         if (! defined('ARTISAN_BINARY')) {
             define('ARTISAN_BINARY', $basePath.'/'.basename($_SERVER['SCRIPT_FILENAME']));


### PR DESCRIPTION
The task scheduler fails to run scheduled commands for projects that are built into a standalone phar archive.

The scheduled task is using the full phar url which doesn't work:

    '/usr/bin/php7.1' 'phar:///path/to/builds/myapp/myapp' test:scheduler > '/dev/null' 2>&1

When I run the above command manually I get the following output;

    Could not open input file: phar:///path/to/builds/myapp/myapp

This PR will detect if running as a phar and set the ARTISAN_BINARY to the path of the phar archive.