### PR TITLE
Add full Illuminate\Events support

### DIFF
--- a/src/Bootstrappers/LoadCommands.php
+++ b/src/Bootstrappers/LoadCommands.php
@@ -30,6 +30,7 @@ class LoadCommands extends Bootstrapper
         Commands\App\Builder::class,
         Commands\App\Renamer::class,
         Commands\App\CommandMaker::class,
+        Commands\Component\Illuminate\Events\Installer::class,
         Commands\Component\Illuminate\Log\Installer::class,
         Commands\Component\Illuminate\Database\Installer::class,
     ];
@@ -97,10 +98,10 @@ class LoadCommands extends Bootstrapper
             foreach ((new Finder)->in($paths)
                          ->files() as $command) {
                 $command = $namespace.str_replace(
-                        ['/', '.php'],
-                        ['\\', ''],
-                        Str::after($command->getPathname(), base_path('app').DIRECTORY_SEPARATOR)
-                    );
+                    ['/', '.php'],
+                    ['\\', ''],
+                    Str::after($command->getPathname(), base_path('app').DIRECTORY_SEPARATOR)
+                );
                 if (is_subclass_of($command, Command::class) && ! (new ReflectionClass($command))->isAbstract()) {
                     $commands[] = $command;
                 }

--- a/src/Bootstrappers/ServiceProviders.php
+++ b/src/Bootstrappers/ServiceProviders.php
@@ -35,6 +35,7 @@ class ServiceProviders extends Bootstrapper
      * @var string[]
      */
     protected $components = [
+        Component\Illuminate\Events\ComponentProvider::class,
         Component\Illuminate\Log\ComponentProvider::class,
         Component\Illuminate\Database\ComponentProvider::class,
     ];

--- a/src/Commands/Component/Illuminate/Events/ComponentProvider.php
+++ b/src/Commands/Component/Illuminate/Events/ComponentProvider.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace LaravelZero\Framework\Commands\Component\Illuminate\Events;
+
+use LaravelZero\Framework\Commands\Component\AbstractComponentProvider;
+
+/**
+ * This is the Laravel Zero Framework illuminate/events component provider class.
+ *
+ */
+class ComponentProvider extends AbstractComponentProvider
+{
+
+    protected $commands = [
+        'EventGenerate' => 'command.event.generate',
+        'EventMake' => 'command.event.make',
+        'ListenerMake' => 'command.listener.make',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isAvailable(): bool
+    {
+        return class_exists(\Illuminate\Events\EventServiceProvider::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register(): void
+    {
+        // Since the LaravelZero Framework requires illuminate\events be installed, the call to isAvailable() above
+        // will always return true. We cannot put this particular conditional in the isAbailable method since
+        // the application isn't fully booted, and we cannot resolve $this->app->getNamespace(). Only when
+        // the application-level EventServiceProvider is present do we register the Event commands.
+        $providerName = $this->app->getNamespace() . 'Providers\EventServiceProvider';
+        if (class_exists($providerName)) {
+            $this->registerServiceProvider($providerName);
+            $this->registerCommands($this->commands);
+        }
+    }
+
+    /**
+    * Register the given commands.
+    *
+    * @param  array  $commands
+    * @return void
+    */
+    protected function registerCommands(array $commands)
+    {
+        foreach (array_keys($commands) as $command) {
+            call_user_func_array([$this, "register{$command}Command"], []);
+        }
+
+        $this->commands(array_values($commands));
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerEventGenerateCommand()
+    {
+        $this->app->singleton('command.event.generate', function () {
+            return new EventGenerateCommand;
+        });
+    }
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerEventMakeCommand()
+    {
+        $this->app->singleton('command.event.make', function ($app) {
+            return new EventMakeCommand($app['files']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerListenerMakeCommand()
+    {
+        $this->app->singleton('command.listener.make', function ($app) {
+            return new ListenerMakeCommand($app['files']);
+        });
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/Dispatchable.php
+++ b/src/Commands/Component/Illuminate/Events/Dispatchable.php
@@ -1,0 +1,14 @@
+<?php namespace LaravelZero\Framework\Commands\Component\Illuminate\Events;
+
+trait Dispatchable
+{
+    /**
+     * Dispatch the event with the given arguments.
+     *
+     * @return void
+     */
+    public static function dispatch()
+    {
+        return event(new static(...func_get_args()));
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/EventGenerateCommand.php
+++ b/src/Commands/Component/Illuminate/Events/EventGenerateCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace LaravelZero\Framework\Commands\Component\Illuminate\Events;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+
+class EventGenerateCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'event:generate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate the missing events and listeners based on registration';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $class = $this->laravel->getNamespace();
+        $class = $class . '\\Providers\\EventServiceProvider';
+        $provider = $this->laravel->make($class, ['app' => $this->getApplication()]);
+
+        foreach ($provider->listens() as $event => $listeners) {
+            $this->makeEventAndListeners($event, $listeners);
+        }
+
+        $this->info('Events and listeners generated successfully!');
+    }
+
+    /**
+     * Make the event and listeners for the given event.
+     *
+     * @param  string  $event
+     * @param  array  $listeners
+     * @return void
+     */
+    protected function makeEventAndListeners($event, $listeners)
+    {
+        if (! Str::contains($event, '\\')) {
+            return;
+        }
+
+        $this->callSilent('make:event', ['name' => $event]);
+
+        $this->makeListeners($event, $listeners);
+    }
+
+    /**
+     * Make the listeners for the given event.
+     *
+     * @param  string  $event
+     * @param  array  $listeners
+     * @return void
+     */
+    protected function makeListeners($event, $listeners)
+    {
+        foreach ($listeners as $listener) {
+            $listener = preg_replace('/@.+$/', '', $listener);
+
+            $this->callSilent('make:listener', array_filter(
+                ['name' => $listener, '--event' => $event]
+            ));
+        }
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/EventMakeCommand.php
+++ b/src/Commands/Component/Illuminate/Events/EventMakeCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace LaravelZero\Framework\Commands\Component\Illuminate\Events;
+
+use Illuminate\Console\GeneratorCommand;
+
+class EventMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:event';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new event class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Event';
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return class_exists($rawName);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/event.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Events';
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/EventServiceProvider.php
+++ b/src/Commands/Component/Illuminate/Events/EventServiceProvider.php
@@ -1,0 +1,57 @@
+<?php namespace LaravelZero\Framework\Commands\Component\Illuminate\Events;
+
+use Illuminate\Support\ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event handler mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [];
+
+    /**
+     * The subscriber classes to register.
+     *
+     * @var array
+     */
+    protected $subscribe = [];
+
+    /**
+     * Register the application's event listeners.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $dispatcher = $this->app->make('events');
+        foreach ($this->listens() as $event => $listeners) {
+            foreach ($listeners as $listener) {
+                $dispatcher->listen($event, $listener);
+            }
+        }
+
+        foreach ($this->subscribe as $subscriber) {
+            $dispatcher->subscribe($subscriber);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register()
+    {
+        //
+    }
+
+    /**
+     * Get the events and handlers.
+     *
+     * @return array
+     */
+    public function listens()
+    {
+        return $this->listen;
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/Installer.php
+++ b/src/Commands/Component/Illuminate/Events/Installer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace LaravelZero\Framework\Commands\Component\Illuminate\Events;
+
+use Illuminate\Filesystem\Filesystem;
+use LaravelZero\Framework\Contracts\Commands\Component\Installer as InstallerContract;
+use LaravelZero\Framework\Commands\Component\Installer as BaseInstaller;
+
+class Installer extends BaseInstaller implements InstallerContract
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $name = 'install:events';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = 'Installs the illuminate/events related generator commands';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getComponentName(): string
+    {
+        return 'events';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install(): bool
+    {
+        $this->installServiceProvider();
+
+        $this->info('Base Component installed! For usage information please reference the Laravel Framework documentation, here: https://laravel.com/docs/5.5/events');
+
+        return true;
+    }
+
+    /**
+     * Installs the application-level EventServiceProvider where users can register their
+     * custom events and event listeners.
+     */
+    protected function installServiceProvider()
+    {
+        $files = $this->laravel->make(Filesystem::class);
+        $stub = str_replace(
+            'DummyNamespace',
+            $this->laravel->getNamespace() . '\Providers',
+            $files->get($this->getStub())
+        );
+
+        $files->put($this->laravel->basePath('app') . '/Providers/' . 'EventServiceProvider.php', $stub);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/event-service-provider.stub';
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/ListenerMakeCommand.php
+++ b/src/Commands/Component/Illuminate/Events/ListenerMakeCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace LaravelZero\Framework\Commands\Component\Illuminate\Events;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+class ListenerMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'make:listener';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new event listener class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Listener';
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $event = $this->option('event');
+
+        if (! Str::startsWith($event, [
+            $this->laravel->getNamespace(),
+            'Illuminate',
+            '\\',
+        ])) {
+            $event = $this->laravel->getNamespace().'Events\\'.$event;
+        }
+
+        return str_replace(
+            ['DummyEvent', 'DummyFullEvent'],
+            [class_basename($event), $event],
+            parent::buildClass($name)
+        );
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('queued')) {
+            return $this->option('event')
+                ? __DIR__.'/stubs/listener-queued.stub'
+                : __DIR__.'/stubs/listener-queued-duck.stub';
+        } else {
+            return $this->option('event')
+                ? __DIR__.'/stubs/listener.stub'
+                : __DIR__.'/stubs/listener-duck.stub';
+        }
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return class_exists($rawName);
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Listeners';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['event', 'e', InputOption::VALUE_OPTIONAL, 'The event class being listened for.'],
+
+            ['queued', null, InputOption::VALUE_NONE, 'Indicates the event listener should be queued.'],
+        ];
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/stubs/event-service-provider.stub
+++ b/src/Commands/Component/Illuminate/Events/stubs/event-service-provider.stub
@@ -1,0 +1,32 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Support\Facades\Event;
+use LaravelZero\Framework\Commands\Component\Illuminate\Events\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array
+     */
+    protected $listen = [
+        'App\Events\Event' => [
+            'App\Listeners\EventListener',
+        ],
+    ];
+
+    /**
+     * Register any events for your application.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        parent::boot();
+
+        //
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/stubs/event.stub
+++ b/src/Commands/Component/Illuminate/Events/stubs/event.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Queue\SerializesModels;
+use LaravelZero\Framework\Commands\Component\Illuminate\Events\Dispatchable;
+
+class DummyClass
+{
+    use Dispatchable, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/stubs/listener-duck.stub
+++ b/src/Commands/Component/Illuminate/Events/stubs/listener-duck.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyClass
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        //
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/stubs/listener-queued-duck.stub
+++ b/src/Commands/Component/Illuminate/Events/stubs/listener-queued-duck.stub
@@ -1,0 +1,32 @@
+<?php
+
+namespace DummyNamespace;
+
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyClass implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  object  $event
+     * @return void
+     */
+    public function handle($event)
+    {
+        //
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/stubs/listener-queued.stub
+++ b/src/Commands/Component/Illuminate/Events/stubs/listener-queued.stub
@@ -1,0 +1,33 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullEvent;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyClass implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  DummyEvent  $event
+     * @return void
+     */
+    public function handle(DummyEvent $event)
+    {
+        //
+    }
+}

--- a/src/Commands/Component/Illuminate/Events/stubs/listener.stub
+++ b/src/Commands/Component/Illuminate/Events/stubs/listener.stub
@@ -1,0 +1,31 @@
+<?php
+
+namespace DummyNamespace;
+
+use DummyFullEvent;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class DummyClass
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  DummyEvent  $event
+     * @return void
+     */
+    public function handle(DummyEvent $event)
+    {
+        //
+    }
+}

--- a/src/Container.php
+++ b/src/Container.php
@@ -4,6 +4,7 @@ namespace LaravelZero\Framework;
 
 use RuntimeException;
 use Illuminate\Container\Container as BaseContainer;
+use Illuminate\Support\Arr;
 use LaravelZero\Framework\Exceptions\NotImplementedException;
 use Illuminate\Contracts\Foundation\Application as LaravelApplication;
 
@@ -243,5 +244,19 @@ class Container extends BaseContainer implements LaravelApplication
     public function getMonologConfigurator()
     {
         return $this->monologConfigurator;
+    }
+
+    /**
+     * Get the registered service provider instances if any exist.
+     *
+     * @param  \Illuminate\Support\ServiceProvider|string  $provider
+     * @return array
+     */
+    public function getProviders($provider)
+    {
+        $name = is_string($provider) ? $provider : get_class($provider);
+        return Arr::where($this->serviceProviders, function ($value) use ($name) {
+            return $value instanceof $name;
+        });
     }
 }


### PR DESCRIPTION
This PR adds additional Illuminate\Events functionality, including the event-related generators found in a core Laravel application.

Since the actual Illuminate\Events component is included as a dependency when installing LaravelZero, the Component Installer I included in this PR actually 'installs' the application-level EventServiceProvider.

I had to include all of the Event-specific generator commands in this PR because unfortunately in the core Laravel Framework, the commands are not in Illuminate\Events, but rather Illuminate\Foundation, which we would not want to pull into the LaravelZero Framework. This is unfortunate, but I don't think it can be resolved unless the commands are moved out of Foundation in a future Laravel release.

The following commands are added with this PR:
+ `install:events` (after the component is installed, the commands below are available)
+ `make:event`
+ `make:listener`
+ `event:generate`

Let me know what you think about this functionality, and if you'd like me to change anything just let me know!

Thank you for your time!
-Adam