### PR TITLE
Remove dev-dependencies to decrease file size

### DIFF
--- a/src/Commands/App/Builder.php
+++ b/src/Commands/App/Builder.php
@@ -15,6 +15,7 @@ use Phar;
 use FilesystemIterator;
 use UnexpectedValueException;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Process\Process;
 use LaravelZero\Framework\Commands\Command;
 
 /**
@@ -200,6 +201,10 @@ class Builder extends Command
             File::put($file, '<?php return ' . var_export($config, true) . ';' . PHP_EOL);
         });
 
+        $this->task('Removing dev dependencies', function () {
+            ($process = new Process("composer install --no-dev", $this->app->basePath()))->run();
+        });
+
         $stub = str_replace('#!/usr/bin/env php', '', File::get($this->app->basePath(ARTISAN_BINARY)));
 
         File::put($this->app->basePath($this->stub), $stub);
@@ -215,6 +220,8 @@ class Builder extends Command
         File::put($this->app->configPath('app.php'), static::$config);
 
         File::delete($this->app->basePath($this->stub));
+
+        ($process = new Process("composer install", $this->app->basePath()))->run();
 
         static::$config = null;
 


### PR DESCRIPTION
Hi @nunomaduro ,

you mentioned during your talk at the PHP Antwerp meetup, that the filesize of the built phar is around 8 megabytes. I looked into this and found out that currently the complete vendor folder gets packaged in the PHAR file.

This PR adds two additional commands to decrease the filesize of the build:

1. When the application gets built, we run `composer install --no-dev` to remove the dev dependencies.
2. In the cleanup part of the build command, we install them back.

In a fresh Laravel Zero application this results in the following filesize change:

Before this PR: 10 megabytes
Without the dev dependencies: 5 megabytes