### PR TITLE
fix file in use error on windows

### DIFF
--- a/src/Commands/App/Builder.php
+++ b/src/Commands/App/Builder.php
@@ -133,6 +133,9 @@ class Builder extends Command
             );
         });
 
+        // Unset the compiler to fix a "file in use" error on Windows.
+        unset($compiler);
+
         $file = $this->app->buildsPath($name);
 
         File::move("$file.phar", $file);


### PR DESCRIPTION
This simple fix will make sure the build command succeeds on Windows.

For some reason the phar builder keeps the file locked in its process, unsetting the compiler unlocks the file.

This fixes https://github.com/laravel-zero/laravel-zero/issues/134