### PR TITLE
Force overriding `handle` by throwing an exception

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -11,6 +11,7 @@
 
 namespace LaravelZero\Framework\Commands;
 
+use LogicException;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Console\Command as BaseCommand;
 
@@ -31,7 +32,10 @@ abstract class Command extends BaseCommand
      *
      * @return void
      */
-    abstract public function handle(): void;
+    public function handle(): void
+    {
+        throw new LogicException('You must override the handle() method in the concrete command class.');
+    }
 
     /**
      * Define the command's schedule.


### PR DESCRIPTION
Instead of using `abstract ...`, which "locks" the implementation in place, we'll throw an exception if this method is not overridden in the implementation. This is to make sure method injection still works in the `handle()` method, because it's called [like this](https://github.com/illuminate/console/blob/master/Command.php#L183).

We _could_ also drop the `abstract` from the class definition, let me know how you feel about that.