### PR TITLE
Add typehints to closures

### DIFF
--- a/src/Bootstrap/LoadConfiguration.php
+++ b/src/Bootstrap/LoadConfiguration.php
@@ -38,7 +38,7 @@ class LoadConfiguration extends BaseLoadConfiguration
          * When artisan starts, sets the application name
          * and the application version.
          */
-        Artisan::starting(function ($artisan) use ($app) {
+        Artisan::starting(function (Artisan $artisan) use ($app) {
             $artisan->setName($app['config']->get('app.name', 'Laravel Zero'));
             $artisan->setVersion($app->version());
         });

--- a/src/Components/Database/Migrator.php
+++ b/src/Components/Database/Migrator.php
@@ -11,6 +11,7 @@
 
 namespace LaravelZero\Framework\Components\Database;
 
+use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 use Illuminate\Database\Migrations\Migrator as BaseMigrator;
 
@@ -32,7 +33,7 @@ class Migrator extends BaseMigrator
     public function getMigrationFiles($paths)
     {
         return collect($paths)->flatMap(function ($path) {
-            return collect((new Finder)->in([$path])->files())->map(function ($file) {
+            return collect((new Finder)->in([$path])->files())->map(function (SplFileInfo $file) {
                 return $file->getPathname();
             })->all();
         })->filter()->sortBy(function ($file) {

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -13,7 +13,6 @@ namespace LaravelZero\Framework;
 
 use ReflectionClass;
 use Illuminate\Console\Application as Artisan;
-use Illuminate\Contracts\Foundation\Application;
 use Symfony\Component\Console\Output\OutputInterface;
 use Illuminate\Foundation\Console\Kernel as BaseKernel;
 
@@ -122,7 +121,7 @@ class Kernel extends BaseKernel
 
         $commands = $commands->diff($toRemoveCommands = $config->get('commands.remove', []));
 
-        Artisan::starting(function ($artisan) use ($toRemoveCommands) {
+        Artisan::starting(function (Artisan $artisan) use ($toRemoveCommands) {
             $reflectionClass = new ReflectionClass(Artisan::class);
             $commands = collect($artisan->all())
                 ->filter(
@@ -145,11 +144,11 @@ class Kernel extends BaseKernel
          * in order to call the schedule method on each Laravel Zero
          * command class.
          */
-        Artisan::starting(function ($artisan) use ($commands) {
+        Artisan::starting(function (Artisan $artisan) use ($commands) {
             $artisan->resolveCommands($commands->toArray());
         });
 
-        Artisan::starting(function ($artisan) use ($config) {
+        Artisan::starting(function (Artisan $artisan) use ($config) {
             collect($artisan->all())->each(function ($command) use ($config) {
                 if (in_array(get_class($command), $config->get('commands.hidden', []))) {
                     $command->setHidden(true);

--- a/src/Providers/GitVersion/GitVersionServiceProvider.php
+++ b/src/Providers/GitVersion/GitVersionServiceProvider.php
@@ -11,6 +11,7 @@
 
 namespace LaravelZero\Framework\Providers\GitVersion;
 
+use Illuminate\Contracts\Console\Application;
 use Symfony\Component\Process\Process;
 use Illuminate\Support\ServiceProvider;
 
@@ -28,7 +29,7 @@ class GitVersionServiceProvider extends ServiceProvider
     {
         $this->app->bind(
             'git.version',
-            function ($app) {
+            function (Application $app) {
                 ($process = new Process('git describe --tags $(git rev-list --tags --max-count=1)', $app->basePath()))->run();
 
                 return trim($process->getOutput()) ?: 'unreleased';


### PR DESCRIPTION
As [SensioLabs Insight mentions](https://insight.sensiolabs.com/projects/2071c54a-6d3a-4d79-ac63-77f4b881a093), closures that accept an object should typehint it for better autocompletion and type safety 🙂 