### PR TITLE
Remove double config call

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -110,7 +110,7 @@ class Kernel extends BaseKernel
             ->merge($config->get('commands.hidden', []));
 
         if ($command = $config->get('commands.default')) {
-            $commands->push($config->get('commands.default'));
+            $commands->push($command);
         }
 
         /*


### PR DESCRIPTION
[SensioLabs Insight](https://insight.sensiolabs.com/projects/2071c54a-6d3a-4d79-ac63-77f4b881a093) noticed that the `$command` variable here wasn't used at all, so I fixed that 🙂 