### PR TITLE
Use proper check to see if TTY is supported

### DIFF
--- a/src/Providers/Composer/Composer.php
+++ b/src/Providers/Composer/Composer.php
@@ -89,7 +89,12 @@ class Composer implements ComposerContract
         $process = new Process($cmd, $cwd);
 
         if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
-            $process->setTty(true);
+            try {
+                $process->setTty(true);
+            } catch (Throwable $e) {
+                // Ignore this error, as it just indicates there is no working TTY available
+                // and the rude check above failed to detect that.
+            }
         }
 
         try {


### PR DESCRIPTION
The old check failed in CI environments, making automatic builds impossible.

Not sure about a test for this, the existing build test mocks the composer part.