### PR TITLE
Add support for Windows OS.

### DIFF
--- a/src/Providers/GitVersion/GitVersionServiceProvider.php
+++ b/src/Providers/GitVersion/GitVersionServiceProvider.php
@@ -35,11 +35,11 @@ final class GitVersionServiceProvider extends ServiceProvider
 
                 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
                     $taskGetLastRevisionTag = 'git rev-list --tags --max-count=1';
-                    
+
                     $process = tap(new Process($taskGetLastRevisionTag, $app->basePath()))->run();
-                    
+
                     $lastRevisionTag = trim($process->getOutput()) ?: 'unreleased';
-                    
+
                     if ($lastRevisionTag === 'unreleased') {
                         return 'unreleased';
                     }

--- a/src/Providers/GitVersion/GitVersionServiceProvider.php
+++ b/src/Providers/GitVersion/GitVersionServiceProvider.php
@@ -31,7 +31,20 @@ final class GitVersionServiceProvider extends ServiceProvider
         $this->app->bind(
             'git.version',
             function (Application $app) {
-                $task = 'git describe --tags $(git rev-list --tags --max-count=1)';
+                $lastRevisionTag = '$(git rev-list --tags --max-count=1)';
+
+                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+                    $taskGetLastRevisionTag = 'git rev-list --tags --max-count=1';
+                    
+                    $process = tap(new Process($taskGetLastRevisionTag, $app->basePath()))->run();
+                    
+                    $lastRevisionTag = trim($process->getOutput()) ?: 'unreleased';
+                    
+                    if ($lastRevisionTag === 'unreleased') {
+                        return 'unreleased';
+                    }
+                }
+                $task = "git describe --tags $lastRevisionTag";
 
                 $process = tap(new Process($task, $app->basePath()))->run();
 


### PR DESCRIPTION
Windows cannot execute a subcommand like "$ ()".