### PR TITLE
Remove single and double quotes from the artisan binary string

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -158,7 +158,7 @@ final class BuildCommand extends Command
      */
     private function getBinary(): string
     {
-        return str_replace(["'", "\""], '', Artisan::artisanBinary());
+        return str_replace(["'", '"'], '', Artisan::artisanBinary());
     }
 
     /**

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -158,7 +158,7 @@ final class BuildCommand extends Command
      */
     private function getBinary(): string
     {
-        return str_replace("'", '', Artisan::artisanBinary());
+        return str_replace(["'", "\""], '', Artisan::artisanBinary());
     }
 
     /**


### PR DESCRIPTION
When running `app:build` on Windows an `ErrorException` is thrown. That's because double quotes are not being removed from the expected filename.

![quotes_not_being_removed](https://user-images.githubusercontent.com/430800/49605667-0b497780-f989-11e8-8d20-2ee3da5f2e0b.png)

On Windows the `escapeArgument()` function on `Illuminate\Support\ProcessUtils` returns a string surrounded by double quotes. So, the `getBinary()` function on `LaravelZero\Framework\Commands\BuildCommand` must take that into account.

Note: this unveils another issue, the phar file is not being created. But I'm still trying to understand that one.