### PR TITLE
Add a timeout option to the build command

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -173,7 +173,7 @@ final class BuildCommand extends Command
      */
     private function getTimeout(): ?float
     {
-        if (! s_numeric($this->option('timeout'))) {
+        if (! is_numeric($this->option('timeout'))) {
             throw new \InvalidArgumentException('The timeout value must be a number.');
         }
 

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -173,7 +173,7 @@ final class BuildCommand extends Command
      */
     private function getTimeout(): ?float
     {
-        if(!is_numeric($this->option('timeout'))) {
+        if (! s_numeric($this->option('timeout'))) {
             throw new \InvalidArgumentException('The timeout value must be a number.');
         }
 

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -26,7 +26,7 @@ final class BuildCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected $signature = 'app:build {name? : The build name}';
+    protected $signature = 'app:build {name? : The build name} {--timeout=300 : The timeout in seconds or 0 to disable}';
 
     /**
      * {@inheritdoc}
@@ -94,7 +94,10 @@ final class BuildCommand extends Command
 
         $process = new Process(
             './box compile'.' --working-dir='.base_path().' --config='.base_path('box.json'),
-            dirname(dirname(__DIR__)).'/bin'
+            dirname(dirname(__DIR__)).'/bin',
+            null,
+            null,
+            $this->getTimeout()
         );
 
         $section = tap($this->originalOutput->section())->write('');
@@ -159,6 +162,24 @@ final class BuildCommand extends Command
     private function getBinary(): string
     {
         return str_replace(["'", '"'], '', Artisan::artisanBinary());
+    }
+
+    /**
+     * Returns a valid timeout value. Non positive values are converted to null,
+     * meaning no timeout.
+     *
+     * @return float|null
+     * @throws \InvalidArgumentException
+     */
+    private function getTimeout(): ?float
+    {
+        if(!is_numeric($this->option('timeout'))) {
+            throw new \InvalidArgumentException('The timeout value must be a number.');
+        }
+
+        $timeout = (float) $this->option('timeout');
+
+        return $timeout > 0 ? $timeout : null;
     }
 
     /**


### PR DESCRIPTION
Add a timeout option to the build command. The user can pass a value, in seconds, to override the default or 0 (or a negative number) to disable the timeout.

Not sure about the default value, though. Is 300 seconds too much? Too little? I based it on the time that it takes on my laptop, but that's just my old laptop... :)

Fixes [laravel-zero/laravel-zero issue #176](https://github.com/laravel-zero/laravel-zero/issues/176)