### PR TITLE
Encloses build command arguments with double quotes.

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -93,7 +93,7 @@ final class BuildCommand extends Command
         }
 
         $process = new Process(
-            './box compile'.' --working-dir='.base_path().' --config='.base_path('box.json'),
+            './box compile'.' --working-dir="'.base_path().'" --config="'.base_path('box.json').'"',
             dirname(dirname(__DIR__)).'/bin',
             null,
             null,


### PR DESCRIPTION
Fixes #309 

The purpose is to allow spaces in directory names when building the app.