### PR TITLE
Fix the app:build command on windows

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -100,8 +100,8 @@ final class BuildCommand extends Command
         }
 
         $process = new Process(
-            './box compile --working-dir="'.base_path().'" --config="'.base_path('box.json').'"',
-            dirname(dirname(__DIR__)).'/bin',
+            (! windows_os() ? './box' : 'box.bat').' compile --working-dir="'.base_path().'" --config="'.base_path('box.json').'"',
+            ! windows_os() ? dirname(dirname(__DIR__)).'/bin' : base_path('vendor'),
             null,
             null,
             $this->getTimeout()


### PR DESCRIPTION
This PR fixes a problem when building the .phar on windows.

The error is ` ErrorException  : rename(W:\projects\app-name\app-name.phar,W:\projects\app-name\builds\app-name): Le fichier spcifi est introuvable. (code: 2)`

This due to the fact that compiling the .phar didn't happen because `./box` doesn't work on windows.

I also tested building the app on a ubuntu machine after removing the `./` and it works