### PR TITLE
New installation timeout

### DIFF
--- a/src/Providers/Composer/Composer.php
+++ b/src/Providers/Composer/Composer.php
@@ -92,7 +92,7 @@ final class Composer implements ComposerContract
     {
         $process = new Process($cmd, $cwd);
 
-        $process->setTimeout(0);
+        $process->setTimeout(300);
 
         if ($process->isTty()) {
             $process->setTty(true);

--- a/src/Providers/Composer/Composer.php
+++ b/src/Providers/Composer/Composer.php
@@ -88,7 +88,7 @@ final class Composer implements ComposerContract
     /**
      * Runs the provided command on the provided folder.
      */
-    private function run(string $cmd, string $cwd = npull): bool
+    private function run(string $cmd, string $cwd = null): bool
     {
         $process = new Process($cmd, $cwd);
 

--- a/src/Providers/Composer/Composer.php
+++ b/src/Providers/Composer/Composer.php
@@ -88,9 +88,11 @@ final class Composer implements ComposerContract
     /**
      * Runs the provided command on the provided folder.
      */
-    private function run(string $cmd, string $cwd = null): bool
+    private function run(string $cmd, string $cwd = npull): bool
     {
         $process = new Process($cmd, $cwd);
+
+        $process->setTimeout(0);
 
         if ($process->isTty()) {
             $process->setTty(true);


### PR DESCRIPTION
When was installing on windows for debugging purposes, the timeout set on `Symfony\Component\Process` quit the application..

This fixes such behaviour.