### PR TITLE
Setup model factories when installing the database component

### DIFF
--- a/src/Components/AbstractInstaller.php
+++ b/src/Components/AbstractInstaller.php
@@ -61,15 +61,16 @@ abstract class AbstractInstaller extends Command implements InstallerContract
      * Requires the provided package.
      *
      * @param  string $package
+     * @param  bool $dev
      *
      * @return \LaravelZero\Framework\Contracts\Commands\Component\InstallerContract
      */
-    protected function require(string $package): InstallerContract
+    protected function require(string $package, bool $dev = false): InstallerContract
     {
         $this->task(
             'Require package via composer',
-            function () use ($package) {
-                return $this->composer->require($package);
+            function () use ($package, $dev) {
+                return $this->composer->require($package, $dev);
             }
         );
 

--- a/src/Components/Database/Installer.php
+++ b/src/Components/Database/Installer.php
@@ -81,6 +81,17 @@ final class Installer extends AbstractInstaller
         );
 
         $this->task(
+            'Creating factories folder',
+            function () {
+                if (File::exists($this->app->databasePath('factories'))) {
+                    return false;
+                }
+
+                File::makeDirectory($this->app->databasePath('factories'), 0755, true, true);
+            }
+        );
+
+        $this->task(
             'Creating default database configuration',
             function () {
                 if (File::exists(config_path('database.php'))) {

--- a/src/Components/Database/Installer.php
+++ b/src/Components/Database/Installer.php
@@ -48,6 +48,7 @@ final class Installer extends AbstractInstaller
     public function install(): void
     {
         $this->require('illuminate/database "5.8.*"');
+        $this->require('fzaninotto/faker "^1.4"', true);
 
         $this->task(
             'Creating a default SQLite database',

--- a/src/Components/Database/Provider.php
+++ b/src/Components/Database/Provider.php
@@ -57,6 +57,7 @@ class Provider extends AbstractComponentProvider
             $this->commands(
                 [
                     \Illuminate\Database\Console\Migrations\MigrateMakeCommand::class,
+                    \Illuminate\Database\Console\Factories\FactoryMakeCommand::class,
                     \Illuminate\Database\Console\Seeds\SeederMakeCommand::class,
                     \Illuminate\Foundation\Console\ModelMakeCommand::class,
                     \Illuminate\Database\Console\Seeds\SeedCommand::class,

--- a/src/Components/Database/Provider.php
+++ b/src/Components/Database/Provider.php
@@ -95,6 +95,14 @@ class Provider extends AbstractComponentProvider
                 }
             );
         }
+
+        if (File::exists($this->app->databasePath('factories'))) {
+            collect(File::files($this->app->databasePath('factories')))->each(
+                function ($file) {
+                    File::requireOnce($file);
+                }
+            );
+        }
     }
 
     /**

--- a/src/Contracts/Providers/ComposerContract.php
+++ b/src/Contracts/Providers/ComposerContract.php
@@ -28,7 +28,7 @@ interface ComposerContract
      * Runs a composer require with
      * the provided package.
      */
-    public function require(string $package): bool;
+    public function require(string $package, bool $dev = false): bool;
 
     /**
      * Runs a composer create-project.

--- a/src/Providers/Composer/Composer.php
+++ b/src/Providers/Composer/Composer.php
@@ -64,9 +64,9 @@ final class Composer implements ComposerContract
     /**
      * {@inheritdoc}
      */
-    public function require(string $package): bool
+    public function require(string $package, bool $dev = false): bool
     {
-        return $this->run("composer require $package", $this->app->basePath());
+        return $this->run("composer require $package".($dev ? ' --dev' : ''), $this->app->basePath());
     }
 
     /**

--- a/tests/DatabaseInstallTest.php
+++ b/tests/DatabaseInstallTest.php
@@ -14,6 +14,7 @@ final class DatabaseInstallTest extends TestCase
     {
         File::delete(database_path('database.sqlite'));
         File::delete(database_path('migrations'));
+        File::delete(database_path('factories'));
         File::delete(database_path('seeds'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php'));
         File::delete(base_path('.gitignore'));
         touch(base_path('.gitignore'));
@@ -41,6 +42,7 @@ final class DatabaseInstallTest extends TestCase
         $this->assertTrue(File::exists(config_path('database.php')));
         $this->assertTrue(File::exists(database_path('database.sqlite')));
         $this->assertTrue(File::exists(database_path('migrations')));
+        $this->assertTrue(File::exists(database_path('factories')));
         $this->assertTrue(File::exists(database_path('seeds'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php')));
     }
 

--- a/tests/DatabaseInstallTest.php
+++ b/tests/DatabaseInstallTest.php
@@ -24,9 +24,12 @@ final class DatabaseInstallTest extends TestCase
     {
         $composerMock = $this->createMock(ComposerContract::class);
 
-        $composerMock->expects($this->once())
+        $composerMock->expects($this->exactly(2))
             ->method('require')
-            ->with('illuminate/database "5.8.*"');
+            ->withConsecutive(
+                ['illuminate/database "5.8.*"', false],
+                ['fzaninotto/faker "^1.4"', true]
+            );
 
         $this->app->instance(ComposerContract::class, $composerMock);
 

--- a/tests/DatabaseProviderTest.php
+++ b/tests/DatabaseProviderTest.php
@@ -31,6 +31,7 @@ final class DatabaseProviderTest extends TestCase
                 \Illuminate\Database\Console\Migrations\ResetCommand::class,
                 \Illuminate\Database\Console\Migrations\RollbackCommand::class,
                 \Illuminate\Database\Console\Migrations\StatusCommand::class,
+                \Illuminate\Database\Console\Factories\FactoryMakeCommand::class,
             ]
         )->map(
             function ($commandClass) use ($commands) {

--- a/tests/QueueInstallTest.php
+++ b/tests/QueueInstallTest.php
@@ -24,7 +24,7 @@ final class QueueInstallTest extends TestCase
         $composerMock = $this->createMock(ComposerContract::class);
 
         // database, queue, bus...
-        $composerMock->expects($this->exactly(3))
+        $composerMock->expects($this->exactly(4))
             ->method('require');
 
         $this->app->instance(ComposerContract::class, $composerMock);


### PR DESCRIPTION
This PR sets up the model factories when installing the database component. This includes:

- Creating the `database/factories` folder
- Registering the `factory:make` command
- Requiring faker as a dev dependency

I didn't create the `UserFactory` file like Laravel does because unlike Laravel Zero doesn't come with a User model by default. I figure it's easy enough to create a factory with the console command when you need one.

I'm personally using the factories to test some of my more complex commands that operate on data stored in sqlite. I had to set everything up manually which took a minute to figure out.

I think it's safe to assume you will want to use the factories if you are using the db component and it's easy enough to ignore or remove them if you don't want to.