### PR TITLE
Move migrations dir step to a separate task

### DIFF
--- a/src/Components/Database/Installer.php
+++ b/src/Components/Database/Installer.php
@@ -55,12 +55,24 @@ final class Installer extends AbstractInstaller
                 if (File::exists(database_path('database.sqlite'))) {
                     return false;
                 }
-                File::makeDirectory($this->app->databasePath('migrations'), 0755, true, true);
+
+                File::makeDirectory($this->app->databasePath(), 0755, true, true);
 
                 File::put(
                     $this->app->databasePath('database.sqlite'),
                     ''
                 );
+            }
+        );
+
+        $this->task(
+            'Creating migrations folder',
+            function () {
+                if (File::exists($this->app->databasePath('migrations'))) {
+                    return false;
+                }
+
+                File::makeDirectory($this->app->databasePath('migrations'), 0755, true, true);
             }
         );
 

--- a/tests/DatabaseInstallTest.php
+++ b/tests/DatabaseInstallTest.php
@@ -12,9 +12,7 @@ final class DatabaseInstallTest extends TestCase
 {
     public function tearDown(): void
     {
-        File::delete(database_path('database.sqlite'));
-        File::delete(database_path('migrations'));
-        File::delete(database_path('seeds'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php'));
+        File::deleteDirectory(database_path());
         File::delete(base_path('.gitignore'));
         touch(base_path('.gitignore'));
     }

--- a/tests/QueueInstallTest.php
+++ b/tests/QueueInstallTest.php
@@ -12,9 +12,7 @@ final class QueueInstallTest extends TestCase
 {
     public function tearDown(): void
     {
-        File::delete(database_path('database.sqlite'));
-        File::delete(database_path('migrations'));
-        File::delete(database_path('seeds'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php'));
+        File::deleteDirectory(database_path());
         File::delete(base_path('.gitignore'));
         touch(base_path('.gitignore'));
     }


### PR DESCRIPTION
This PR moves creating the database/migrations folder to it's own task and verifies the folder does not exist before creating it. This will avoid a warning if the folder already exists.