### PR TITLE
Add missing db:wipe command

### DIFF
--- a/src/Components/Database/Provider.php
+++ b/src/Components/Database/Provider.php
@@ -74,6 +74,7 @@ class Provider extends AbstractComponentProvider
                 \Illuminate\Database\Console\Migrations\ResetCommand::class,
                 \Illuminate\Database\Console\Migrations\RollbackCommand::class,
                 \Illuminate\Database\Console\Migrations\StatusCommand::class,
+                \Illuminate\Database\Console\WipeCommand::class,
             ]
         );
     }

--- a/tests/DatabaseProviderTest.php
+++ b/tests/DatabaseProviderTest.php
@@ -32,6 +32,7 @@ final class DatabaseProviderTest extends TestCase
                 \Illuminate\Database\Console\Migrations\RollbackCommand::class,
                 \Illuminate\Database\Console\Migrations\StatusCommand::class,
                 \Illuminate\Database\Console\Factories\FactoryMakeCommand::class,
+                \Illuminate\Database\Console\WipeCommand::class,
             ]
         )->map(
             function ($commandClass) use ($commands) {


### PR DESCRIPTION
This adds the `db:wipe` command to the database [Provider](src/Components/Database/Provider.php). This command is required by the `migrate:fresh` [command](https://github.com/illuminate/database/blob/62ce95bd5a6f80afec07cfceec5aec093010b479/Console/Migrations/FreshCommand.php#L40).

This Command was added to the production allowed set. This was done simply because the `migrate:fresh` command exists in the same set.

Prior to this change, the Laravel-Zero package cannot run the `migrate:fresh` command out of the box. 

Steps to reproduce the error:

1. `composer global require "laravel-zero/installer"`
2. `laravel-zero new <your-app-name> && cd <your-app-name>`
3. `php <your-app-name> app:install database`
4. `php <your-app-name> migrate:fresh`

You don't need to have any migrations created to run a migrate-fresh, so that is the least needed to reproduce the error.

Error Output:
```bash
root@0bc79a759c6c:/test-cli# php test-cli migrate:fresh

Command "db:wipe" is not defined.  
Did you mean this?                 
    db:seed                        
                                     
```