### PR TITLE
Allow for overriding Default Providers on Installed components

### DIFF
--- a/src/Components/Database/Provider.php
+++ b/src/Components/Database/Provider.php
@@ -29,9 +29,9 @@ class Provider extends AbstractComponentProvider
      */
     public function isAvailable(): bool
     {
-        return class_exists(\Illuminate\Database\DatabaseServiceProvider::class) && is_array(
-                $this->app['config']->get('database', false)
-            );
+        return class_exists(\Illuminate\Database\DatabaseServiceProvider::class)
+            && is_array($this->app['config']->get('database', false))
+            && $this->app['config']->get('database.useDefaultProvider', true) === true;
     }
 
     /**

--- a/src/Components/Database/stubs/database.php
+++ b/src/Components/Database/stubs/database.php
@@ -6,6 +6,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Use Default Database Provider
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify if you are using a database provider or the default.
+    | If you wish to extend the database provider you can set it to false
+    | and it add your provider in to override the defaults.
+    |
+    */
+
+    'useDefaultProvider' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Database Connection Name
     |--------------------------------------------------------------------------
     |

--- a/src/Components/Database/stubs/database.php
+++ b/src/Components/Database/stubs/database.php
@@ -10,8 +10,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Here you may specify if you are using a database provider or the default.
-    | If you wish to extend the database provider you can set it to false
-    | and it add your provider in to override the defaults.
+    | If you wish to extend the database provider you can set this to false
+    | and then add your provider in to override the defaults.
     |
     */
 

--- a/src/Components/Log/Provider.php
+++ b/src/Components/Log/Provider.php
@@ -26,7 +26,8 @@ final class Provider extends AbstractComponentProvider
      */
     public function isAvailable(): bool
     {
-        return class_exists(\Illuminate\Log\LogServiceProvider::class);
+        return class_exists(\Illuminate\Log\LogServiceProvider::class)
+            && $this->app['config']->get('logging.useDefaultProvider', true) === true;
     }
 
     /**

--- a/src/Components/Log/stubs/logging.php
+++ b/src/Components/Log/stubs/logging.php
@@ -8,6 +8,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Use Default Logging Provider
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify if you are using a logging provider or the default.
+    | If you wish to extend the logging provider you can set this to false
+    | and it add your provider in to override the defaults.
+    |
+    */
+
+    'useDefaultProvider' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Log Channel
     |--------------------------------------------------------------------------
     |

--- a/src/Components/Log/stubs/logging.php
+++ b/src/Components/Log/stubs/logging.php
@@ -13,7 +13,7 @@ return [
     |
     | Here you may specify if you are using a logging provider or the default.
     | If you wish to extend the logging provider you can set this to false
-    | and it add your provider in to override the defaults.
+    | and then add your provider in to override the defaults.
     |
     */
 

--- a/src/Components/Queue/Provider.php
+++ b/src/Components/Queue/Provider.php
@@ -26,9 +26,10 @@ final class Provider extends AbstractComponentProvider
      */
     public function isAvailable(): bool
     {
-        return class_exists(\Illuminate\Bus\BusServiceProvider::class) && class_exists(
-                \Illuminate\Queue\QueueServiceProvider::class
-            ) && file_exists($this->app->configPath('queue.php'));
+        return class_exists(\Illuminate\Bus\BusServiceProvider::class)
+            && class_exists(\Illuminate\Queue\QueueServiceProvider::class)
+            && file_exists($this->app->configPath('queue.php'))
+            && $this->app['config']->get('queue.useDefaultProvider', true) === true;
     }
 
     /**

--- a/src/Components/Queue/stubs/queue.php
+++ b/src/Components/Queue/stubs/queue.php
@@ -4,6 +4,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Use Default Queue Provider
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify if you are using a queue provider or the default.
+    | If you wish to extend the queue provider you can set this to false
+    | and then add your provider in to override the defaults.
+    |
+    */
+
+    'useDefaultProvider' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Queue Connection Name
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
* Add flag to Database Provider for overriding
* Add flag to Logging Provider for overriding
* Add flag to Queue Provider for overriding

These flags allow you to override the Default Providers with your own implementation. The flags default to `true` so that the `Laravel-Zero/Framework` package works right out of the box.

These changes are in reference to https://github.com/laravel-zero/laravel-zero/issues/203.

> These changes add flags to the Installed `Components'` `isAvailable()` method. This flag allows for a developer to easily override the default provider for that installed package.
> 
> One concern that exemplifies this is if you wanted to use the `Database Component`, but needed a way to override the `Migrator` for some reason. [With how `Service Providers` are loaded](https://github.com/laravel-zero/framework/blob/stable/src/Bootstrap/RegisterProviders.php#L69) the default providers are actually loaded in after the Custom Providers. This makes it very hard to override singletons that are built from the Default Providers.

