### PR TITLE
Remove 'useDefaultProvider' from config stubs

### DIFF
--- a/src/Components/Database/stubs/database.php
+++ b/src/Components/Database/stubs/database.php
@@ -6,19 +6,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Use Default Database Provider
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify if you are using a database provider or the default.
-    | If you wish to extend the database provider you can set this to false
-    | and then add your provider in to override the defaults.
-    |
-    */
-
-    'useDefaultProvider' => true,
-
-    /*
-    |--------------------------------------------------------------------------
     | Default Database Connection Name
     |--------------------------------------------------------------------------
     |

--- a/src/Components/Log/stubs/logging.php
+++ b/src/Components/Log/stubs/logging.php
@@ -8,19 +8,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Use Default Logging Provider
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify if you are using a logging provider or the default.
-    | If you wish to extend the logging provider you can set this to false
-    | and then add your provider in to override the defaults.
-    |
-    */
-
-    'useDefaultProvider' => true,
-
-    /*
-    |--------------------------------------------------------------------------
     | Default Log Channel
     |--------------------------------------------------------------------------
     |

--- a/src/Components/Queue/stubs/queue.php
+++ b/src/Components/Queue/stubs/queue.php
@@ -4,19 +4,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Use Default Queue Provider
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify if you are using a queue provider or the default.
-    | If you wish to extend the queue provider you can set this to false
-    | and then add your provider in to override the defaults.
-    |
-    */
-
-    'useDefaultProvider' => true,
-
-    /*
-    |--------------------------------------------------------------------------
     | Default Queue Connection Name
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
As per https://github.com/laravel-zero/framework/pull/370#discussion_r363860979, this removes the `useDefaultProvider` keys from the configuration stubs. This information can then be moved to the documentation.

I'll open the documentation changes as another PR.