### PR TITLE
Update Logo component to use Laminus Text

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
         "illuminate/database": "^6.0",
         "laminas/laminas-text": "^2.7",
         "padraic/phar-updater": "^1.0.6",
-        "zendframework/zend-text": "^2.7",
         "nunomaduro/laravel-console-menu": "^2.2",
         "nunomaduro/laravel-console-dusk": "^1.4",
         "hmazter/laravel-schedule-list": "^2.0"

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,7 @@
         "illuminate/log": "^6.0",
         "illuminate/queue": "^6.0",
         "illuminate/database": "^6.0",
+        "laminas/laminas-text": "^2.7",
         "padraic/phar-updater": "^1.0.6",
         "zendframework/zend-text": "^2.7",
         "nunomaduro/laravel-console-menu": "^2.2",

--- a/src/Components/Logo/FigletString.php
+++ b/src/Components/Logo/FigletString.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace LaravelZero\Framework\Components\Logo;
 
 use InvalidArgumentException;
-use Zend\Text\Figlet\Figlet as ZendFiglet;
+use Laminas\Text\Figlet\Figlet;
 
 /**
  * @internal
@@ -23,6 +23,7 @@ final class FigletString
 {
     private $string;
 
+    /** @var Figlet */
     private $figlet;
 
     public const DEFAULT_FONT = __DIR__.DIRECTORY_SEPARATOR.'fonts'.DIRECTORY_SEPARATOR.'big.flf';
@@ -30,7 +31,7 @@ final class FigletString
     public function __construct(string $string, array $options)
     {
         $this->string = $string;
-        $this->figlet = new ZendFiglet();
+        $this->figlet = new Figlet();
 
         $this->parseOptions($options);
     }
@@ -66,16 +67,16 @@ final class FigletString
     {
         switch ($justification) {
             case 'left':
-                $this->figlet->setJustification(ZendFiglet::JUSTIFICATION_LEFT);
+                $this->figlet->setJustification(Figlet::JUSTIFICATION_LEFT);
                 break;
             case 'center':
-                $this->figlet->setJustification(ZendFiglet::JUSTIFICATION_CENTER);
+                $this->figlet->setJustification(Figlet::JUSTIFICATION_CENTER);
                 break;
             case 'right':
-                $this->figlet->setJustification(ZendFiglet::JUSTIFICATION_RIGHT);
+                $this->figlet->setJustification(Figlet::JUSTIFICATION_RIGHT);
                 break;
             case null:
-                // Let ZendFiglet handle the justification
+                // Let Figlet handle the justification
                 break;
             default:
                 throw new InvalidArgumentException('Invalid value given for the `logo.justification` option');
@@ -88,13 +89,13 @@ final class FigletString
     {
         switch ($rightToLeft) {
             case 'right-to-left':
-                $this->figlet->setRightToLeft(ZendFiglet::DIRECTION_RIGHT_TO_LEFT);
+                $this->figlet->setRightToLeft(Figlet::DIRECTION_RIGHT_TO_LEFT);
                 break;
             case 'left-to-right':
-                $this->figlet->setRightToLeft(ZendFiglet::DIRECTION_LEFT_TO_RIGHT);
+                $this->figlet->setRightToLeft(Figlet::DIRECTION_LEFT_TO_RIGHT);
                 break;
             case null:
-                // Let ZendFiglet handle this
+                // Let Figlet handle this
                 break;
             default:
                 throw new \InvalidArgumentException('Invalid value given for the `logo.rightToLeft` option');

--- a/src/Components/Logo/Installer.php
+++ b/src/Components/Logo/Installer.php
@@ -41,7 +41,7 @@ final class Installer extends AbstractInstaller
      */
     public function install(): void
     {
-        $this->require('zendframework/zend-text "^2.7"');
+        $this->require('laminas/laminas-text "^2.7"');
 
         $this->task(
             'Creating default logo configuration',

--- a/src/Components/Logo/Provider.php
+++ b/src/Components/Logo/Provider.php
@@ -27,9 +27,8 @@ final class Provider extends AbstractComponentProvider
      */
     public function isAvailable(): bool
     {
-        return class_exists(\Zend\Text\Figlet\Figlet::class) && is_array(
-                $this->app['config']->get('logo', false)
-            );
+        return class_exists(\Laminas\Text\Figlet\Figlet::class)
+            && is_array($this->app['config']->get('logo', false));
     }
 
     /**

--- a/tests/LogoInstallTest.php
+++ b/tests/LogoInstallTest.php
@@ -21,7 +21,7 @@ final class LogoInstallTest extends TestCase
 
         $composerMock->expects($this->once())
             ->method('require')
-            ->with('zendframework/zend-text "^2.7"');
+            ->with('laminas/laminas-text "^2.7"');
 
         $this->app->instance(ComposerContract::class, $composerMock);
 


### PR DESCRIPTION
As per https://github.com/laravel-zero/laravel-zero/issues/253#issuecomment-574227639, it looks like the Zend Text package with figlet functionality has been moved to [`laminus-text`](https://github.com/laminas/laminas-text).

However, the underlying issue (https://github.com/laravel-zero/laravel-zero/issues/253) with the figlet font that we use still remains.