### PR TITLE
Update dependencies to prepare for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/database": "^6.0",
         "laminas/laminas-text": "^2.7",
         "padraic/phar-updater": "^1.0.6",
-        "nunomaduro/laravel-console-menu": "^2.2",
+        "nunomaduro/laravel-console-menu": "^2.3",
         "nunomaduro/laravel-console-dusk": "^1.4",
         "hmazter/laravel-schedule-list": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "padraic/phar-updater": "^1.0.6",
         "nunomaduro/laravel-console-menu": "^2.3",
         "nunomaduro/laravel-console-dusk": "^1.6",
-        "hmazter/laravel-schedule-list": "^2.0"
+        "hmazter/laravel-schedule-list": "^2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "league/flysystem": "^1.0.8",
         "nunomaduro/collision": "^3.0",
         "nunomaduro/laravel-console-summary": "^1.3",
-        "nunomaduro/laravel-console-task": "^1.3",
+        "nunomaduro/laravel-console-task": "^1.4",
         "nunomaduro/laravel-desktop-notifier": "^2.2",
         "psr/log": "^1.1",
         "symfony/console": "^4.3",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "laravel-zero/foundation": "^6.0",
         "league/flysystem": "^1.0.8",
         "nunomaduro/collision": "^3.0",
-        "nunomaduro/laravel-console-summary": "^1.2",
+        "nunomaduro/laravel-console-summary": "^1.3",
         "nunomaduro/laravel-console-task": "^1.3",
         "nunomaduro/laravel-desktop-notifier": "^2.2",
         "psr/log": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "laminas/laminas-text": "^2.7",
         "padraic/phar-updater": "^1.0.6",
         "nunomaduro/laravel-console-menu": "^2.3",
-        "nunomaduro/laravel-console-dusk": "^1.4",
+        "nunomaduro/laravel-console-dusk": "^1.6",
         "hmazter/laravel-schedule-list": "^2.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "nunomaduro/collision": "^3.0",
         "nunomaduro/laravel-console-summary": "^1.3",
         "nunomaduro/laravel-console-task": "^1.4",
-        "nunomaduro/laravel-desktop-notifier": "^2.2",
+        "nunomaduro/laravel-desktop-notifier": "^2.3",
         "psr/log": "^1.1",
         "symfony/console": "^4.3",
         "symfony/debug": "^4.3",

--- a/src/Components/Menu/Installer.php
+++ b/src/Components/Menu/Installer.php
@@ -35,6 +35,6 @@ final class Installer extends AbstractInstaller
      */
     public function install(): void
     {
-        $this->require('nunomaduro/laravel-console-menu "^2.1"');
+        $this->require('nunomaduro/laravel-console-menu "^2.3"');
     }
 }

--- a/src/Components/ScheduleList/Installer.php
+++ b/src/Components/ScheduleList/Installer.php
@@ -42,7 +42,7 @@ final class Installer extends AbstractInstaller
      */
     public function install(): void
     {
-        $this->require('hmazter/laravel-schedule-list "^2.0"');
+        $this->require('hmazter/laravel-schedule-list "^2.1"');
 
         $this->task(
             'Creating default schedule list configuration',

--- a/tests/ScheduleListInstallTest.php
+++ b/tests/ScheduleListInstallTest.php
@@ -16,7 +16,7 @@ final class ScheduleListInstallTest extends TestCase
 
         $composerMock->expects($this->once())
             ->method('require')
-            ->with('hmazter/laravel-schedule-list "^2.0"');
+            ->with('hmazter/laravel-schedule-list "^2.1"');
 
         $this->app->instance(ComposerContract::class, $composerMock);
 


### PR DESCRIPTION
This updates the following dependencies to versions that support Laravel 7:

- Laravel Console Dusk
- Laravel Console Menu
- Laravel Console Summary
- Laravel Console Task
- Laravel Desktop Notifier
- Laravel Schedule List

It also updates the minimum versions required in the component installers for the Menu and Schedule List components.

This just makes the process of updating Laravel Zero to version 7 easier in future.