### PR TITLE
Fix laravel-zero/laravel-zero #226

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace LaravelZero\Framework\Commands;
 
-use function func_get_args;
 use Illuminate\Console\Command as BaseCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use LaravelZero\Framework\Providers\CommandRecorder\CommandRecorderRepository;
+use function func_get_args;
 use function str_repeat;
 use function strlen;
 
@@ -32,7 +32,7 @@ abstract class Command extends BaseCommand
     /**
      * Define the command's schedule.
      *
-     * @param  \Illuminate\Console\Scheduling\Schedule $schedule
+     * @param \Illuminate\Console\Scheduling\Schedule $schedule
      * @return void
      */
     public function schedule(Schedule $schedule)
@@ -104,4 +104,86 @@ abstract class Command extends BaseCommand
 
         return $this;
     }
+
+    /**
+     * @param int $count
+     * @return Command
+     */
+    public function newLine(int $count = 1)
+    {
+        $this->output->newLine($count);
+
+        return $this;
+    }
+
+    /**
+     * @param string|string[] $message
+     * @return Command
+     */
+    public function successBlock($message)
+    {
+        $this->output->success($message);
+
+        return $this;
+    }
+
+    /**
+     * @param array $elements
+     * @return $this
+     */
+    public function listing(array $elements)
+    {
+        $this->output->listing($elements);
+
+        return $this;
+    }
+
+    /**
+     * @param string|string[] $message
+     * @return $this
+     */
+    public function write($message)
+    {
+        $this->output->write($message);
+
+        return $this;
+    }
+
+    /**
+     * @param string|string[] $message
+     */
+    public function errorBlock($message)
+    {
+        $this->output->error($message);
+    }
+
+    /**
+     * @return self
+     */
+    public function progressStart()
+    {
+        $this->output->progressStart();
+
+        return $this;
+    }
+
+    /**
+     * @param int $step
+     * @return self
+     */
+    public function progressAdvance(int $step = 1)
+    {
+        $this->output->progressAdvance($step);
+
+        return $this;
+    }
+
+    public function progressFinish()
+    {
+        $this->output->progressFinish();
+
+        return $this;
+    }
+
+
 }

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -128,6 +128,17 @@ abstract class Command extends BaseCommand
     }
 
     /**
+     * @param string|string[] $message
+     * @return Command
+     */
+    public function warningBlock($message)
+    {
+        $this->output->warning($message);
+
+        return $this;
+    }
+
+    /**
      * @param array $elements
      * @return $this
      */
@@ -184,6 +195,4 @@ abstract class Command extends BaseCommand
 
         return $this;
     }
-
-
 }

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -57,11 +57,11 @@ final class InstallCommand extends Command
             $choices[$name] = $this->app->make($componentClass)->getDescription();
         }
 
-        if (! $option = $this->argument('component')) {
+        if (!$option = $this->argument('component')) {
             $option = $this->choice($title, $choices);
         }
 
-        if ($option !== null && ! empty($this->components[$option])) {
+        if ($option !== null && !empty($this->components[$option])) {
             $command = tap($this->app[$this->components[$option]])->setLaravel($this->app);
 
             $command->setApplication($this->getApplication());


### PR DESCRIPTION
This is an attempt to resolve https://github.com/laravel-zero/laravel-zero/issues/266. Functions like `warn, error, info` output a line of it's type. So, I added `successBlock`,`errorBlock`,`warningBlock`. I'm not sure about the Progress Bar API, maybe instead of `progressStart()`, `progressAdvance()`, `progressFinish()` something like that :
```php
$this->progress->start();
$this->progress->increase(10);
$this->progress->decrease(5);
$this->progress->finish();
```
I also found nothing to test these methods.
I'm also asking for the support of an array of string in these methods: `warn`, `error` as it's sometimes useful when dealing with generated content.