### PR TITLE
Fix the logo component in Symfony 5

### DIFF
--- a/src/Components/Logo/Provider.php
+++ b/src/Components/Logo/Provider.php
@@ -42,7 +42,7 @@ final class Provider extends AbstractComponentProvider
             Artisan::starting(
                 function ($artisan) use ($config) {
                     $artisan->setName(
-                        new FigletString($config->get('app.name'), $config->get('logo', []))
+                        (string) new FigletString($config->get('app.name'), $config->get('logo', []))
                     );
                 }
             );


### PR DESCRIPTION
Since Symfony 5 (https://github.com/symfony/console/commit/18d6e02b6cbec317e0fa1410bb783cdd954edf05), the `console` component now includes type hints for the `setName()` method.

This forces the `FigletString` object to be cast to a string before setting the name and resolves the following error:
```log
laravel-zero on  7.x [!?] via  v7.4.2
❯ php .\application

   TypeError

  Argument 1 passed to Symfony\Component\Console\Application::setName() must be of the type string, object given, called in C:\Users\owen.voke\projects\laravel-zero\vendor\laravel-zero\framework\src\Components\Logo\Provider.php on line 45
  at C:\Users\owen.voke\projects\laravel-zero\vendor\symfony\console\Application.php:381
    377|
    378|     /**
    379|      * Sets the application name.
    380|      **/
  > 381|     public function setName(string $name)
    382|     {
    383|         $this->name = $name;
    384|     }
    385|

  1   C:\Users\owen.voke\projects\laravel-zero\vendor\laravel-zero\framework\src\Components\Logo\Provider.php:45             Symfony\Component\Console\Application::setName(Object(LaravelZero\Framework\Components\Logo\FigletString))       
  2   C:\Users\owen.voke\projects\laravel-zero\vendor\illuminate\console\Application.php:152
      LaravelZero\Framework\Components\Logo\Provider::LaravelZero\Framework\Components\Logo\{closure}(Object(Illuminate\Console\Application))
```