### PR TITLE
Stub publish command

### DIFF
--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -34,14 +34,6 @@ final class MakeCommand extends ConsoleMakeCommand
     /**
      * {@inheritdoc}
      */
-    protected function getStub(): string
-    {
-        return __DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'console.stub';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace.'\Commands';

--- a/src/Commands/StubPublishCommand.php
+++ b/src/Commands/StubPublishCommand.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace LaravelZero\Framework\Commands;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Console\StubPublishCommand as BaseStubPublishCommand;
+
+class StubPublishCommand extends BaseStubPublishCommand
+{
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! is_dir($stubsPath = $this->laravel->basePath('stubs'))) {
+            (new Filesystem)->makeDirectory($stubsPath);
+        }
+
+        $files = [
+            __DIR__.'/stubs/console.stub' => $stubsPath.'/console.stub',
+        ];
+
+        foreach ($files as $from => $to) {
+            if (! file_exists($to) || $this->option('force')) {
+                file_put_contents($to, file_get_contents($from));
+            }
+        }
+
+        $this->info('Stubs published successfully.');
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -37,6 +37,7 @@ class Kernel extends BaseKernel
         Commands\RenameCommand::class,
         Commands\MakeCommand::class,
         Commands\InstallCommand::class,
+        Commands\StubPublishCommand::class,
     ];
 
     /**


### PR DESCRIPTION
This PR adds a `stub:publish` command that matches the [same command in Laravel](https://laravel.com/docs/7.x/artisan#stub-customization)

This would also require updating the mirror of laravel/framework at laravel-zero/foundation to include the changes to `Illuminate\Foundation\Console\ConsoleMakeCommand` that support the use of customised stubs, specifically the [`getStub` method](https://github.com/laravel/framework/blob/7.x/src/Illuminate/Foundation/Console/ConsoleMakeCommand.php#L51)

```php
protected function getStub()
{
    $relativePath = '/stubs/console.stub';

    return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
        ? $customPath
        : __DIR__.$relativePath;
}
```