### PR TITLE
Add support for custom update strategies

### DIFF
--- a/src/Components/Updater/Provider.php
+++ b/src/Components/Updater/Provider.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace LaravelZero\Framework\Components\Updater;
 
-use LaravelZero\Framework\Components\Updater\Strategy\GithubStrategy;
 use function class_exists;
 use Humbug\SelfUpdate\Updater as PharUpdater;
 use LaravelZero\Framework\Components\AbstractComponentProvider;
+use LaravelZero\Framework\Components\Updater\Strategy\GithubStrategy;
 use LaravelZero\Framework\Providers\Build\Build;
 
 /**

--- a/src/Components/Updater/Provider.php
+++ b/src/Components/Updater/Provider.php
@@ -38,6 +38,14 @@ final class Provider extends AbstractComponentProvider
     {
         $build = $this->app->make(Build::class);
 
+        if (! $this->app->environment('production')) {
+            $this->publishes([
+                __DIR__.'/config/updater.php' => $this->app->configPath('updater.php'),
+            ]);
+        }
+
+        $this->mergeConfigFrom(__DIR__.'/config/updater.php', 'updater');
+
         if ($build->isRunning() && $this->app->environment() === 'production') {
             $this->commands([
                 SelfUpdateCommand::class,

--- a/src/Components/Updater/Provider.php
+++ b/src/Components/Updater/Provider.php
@@ -59,7 +59,8 @@ final class Provider extends AbstractComponentProvider
                 $composer = json_decode(file_get_contents(base_path('composer.json')), true);
                 $name = $composer['name'];
 
-                $updater->setStrategyObject(new GithubStrategy);
+                $strategy = $this->app['config']->get('updater.strategy', GithubStrategy::class);
+                $updater->setStrategyObject(new $strategy);
 
                 $updater->getStrategy()->setPackageName($name);
 

--- a/src/Components/Updater/Provider.php
+++ b/src/Components/Updater/Provider.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace LaravelZero\Framework\Components\Updater;
 
+use LaravelZero\Framework\Components\Updater\Strategy\GithubStrategy;
 use function class_exists;
 use Humbug\SelfUpdate\Updater as PharUpdater;
 use LaravelZero\Framework\Components\AbstractComponentProvider;

--- a/src/Components/Updater/Strategy/GithubReleasesStrategy.php
+++ b/src/Components/Updater/Strategy/GithubReleasesStrategy.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelZero\Framework\Components\Updater\Strategy;
+
+final class GithubReleasesStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy implements StrategyInterface
+{
+}

--- a/src/Components/Updater/Strategy/GithubStrategy.php
+++ b/src/Components/Updater/Strategy/GithubStrategy.php
@@ -1,13 +1,10 @@
 <?php
 
-namespace LaravelZero\Framework\Components\Updater;
+namespace LaravelZero\Framework\Components\Updater\Strategy;
 
 use Phar;
 
-/**
- * @internal
- */
-final class GithubStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy
+final class GithubStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy implements StrategyInterface
 {
     /**
      * Returns the Download Url.

--- a/src/Components/Updater/Strategy/StrategyInterface.php
+++ b/src/Components/Updater/Strategy/StrategyInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace LaravelZero\Framework\Components\Updater\Strategy;
+
+interface StrategyInterface extends \Humbug\SelfUpdate\Strategy\StrategyInterface
+{
+}

--- a/src/Components/Updater/config/updater.php
+++ b/src/Components/Updater/config/updater.php
@@ -1,0 +1,20 @@
+<?php
+
+use LaravelZero\Framework\Components\Updater\GithubStrategy;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Self-updater Strategy
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify which update strategy class you wish to use when
+    | updating your application via the "self-update" command. This must
+    | be a class that implements the StrategyInterface from Humbug.
+    |
+    */
+
+    'strategy' => GithubStrategy::class,
+
+];

--- a/src/Components/Updater/config/updater.php
+++ b/src/Components/Updater/config/updater.php
@@ -1,6 +1,6 @@
 <?php
 
-use LaravelZero\Framework\Components\Updater\GithubStrategy;
+use LaravelZero\Framework\Components\Updater\Strategy\GithubStrategy;
 
 return [
 


### PR DESCRIPTION
I was looking back through older issues and found #218, this is something that I've wanted various times. The PR is really simple and basically allows you to specify any custom PharUpdater strategy, it's backward compatible as the default is the [`GitHubStrategy`](https://github.com/laravel-zero/framework/blob/f76b8cf12a6ca54ebbb27bab5d64a2db43f3b80c/src/Components/Updater/GithubStrategy.php) included in the component.

I'll open a PR to the docs repository as well to outline that a new `config/updater.php` can be created using the `vendor:publish` command.

---

There are now the following strategies available:

- `LaravelZero\Framework\Components\Updater\Strategy\GitHubStrategy`
- `LaravelZero\Framework\Components\Updater\Strategy\GitHubReleasesStrategy`

---

Closes https://github.com/laravel-zero/laravel-zero/issues/218