### PR TITLE
Fix box builds with spaces in path on Windows

### DIFF
--- a/bin/box.bat
+++ b/bin/box.bat
@@ -1,2 +1,2 @@
 @echo off
-php %~dp0/box %*
+php "%~dp0box" %*


### PR DESCRIPTION
I had the issue with laravel-zero/framework 7.0.
For me the issue was with the path of box file
The command `php %~dp0/box %*` does not get names with spaces in them so i used this 
`php "%~dp0box" %*`

Created PR

---

Closes https://github.com/laravel-zero/laravel-zero/issues/290