### PR TITLE
Update CI to also check lowest dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: [7.2, 7.3, 7.4]
-        dependency-version: [prefer-stable]
+        dependency-version: [prefer-lowest, prefer-stable]
 
     name: CI - PHP ${{ matrix.php }} (${{ matrix.dependency-version }})
 


### PR DESCRIPTION
This is part of the discussion for https://github.com/laravel-zero/laravel-zero/pull/291, where the framework should be tested on `--prefer-lowest` to make sure that the dependencies always work, whereas `laravel-zero/laravel-zero` uses a lock file so it's less important as the dependencies should be updated. 👍