### PR TITLE
Remove PHPUnit as it's an explicit Pest dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,9 +53,8 @@
         "nunomaduro/laravel-console-dusk": "^1.6",
         "nunomaduro/laravel-console-menu": "^2.3",
         "padraic/phar-updater": "^1.0.6",
-        "pestphp/pest": "^0.1.2",
-        "phpstan/phpstan": "^0.12",
-        "phpunit/phpunit": "^9.0"
+        "pestphp/pest": "^0.1.5",
+        "phpstan/phpstan": "^0.12"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This also bumps Pest to the latest version.