### PR TITLE
Add support for Collision 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "illuminate/testing": "^7.0",
         "laravel-zero/foundation": "^7.0",
         "league/flysystem": "^1.0.8",
-        "nunomaduro/collision": "^4.1",
+        "nunomaduro/collision": "^4.1||^5.0",
         "nunomaduro/laravel-console-summary": "^1.4",
         "nunomaduro/laravel-console-task": "^1.4",
         "nunomaduro/laravel-desktop-notifier": "^2.3",


### PR DESCRIPTION
This will already be applied in [v8 of Laravel Zero](https://github.com/laravel-zero/framework/blob/8ccfdae8aa2a7bdeb2b5c9bc811309237844be32/composer.json#L32), however for v7 it's currently not possible to use things such as Pest as they require Collision v5. By default, it will stay on v4 of Collision.