### PR TITLE
ci: update Style CI configuration

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,3 +1,1 @@
 preset: laravel
-disabled:
-  - self_accessor


### PR DESCRIPTION
Looks like this was causing issues with Style CI as the `self_accessor` fixer was moved [to the **Laravel risky** section](https://docs.styleci.io/presets#laravel).