### PR TITLE
Updater GitLab strategy implementation

### DIFF
--- a/src/Components/Updater/Strategy/GitlabStrategy.php
+++ b/src/Components/Updater/Strategy/GitlabStrategy.php
@@ -1,0 +1,26 @@
+<?php
+
+
+    namespace LaravelZero\Framework\Components\Updater\Strategy;
+
+    use Phar;
+
+    class GitlabStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy implements StrategyInterface
+    {
+        /**
+         * Returns the Download Url.
+         *
+         * @param array $package
+         *
+         * @return string
+         */
+        protected function getDownloadUrl(array $package): string{
+
+            $downloadUrl = parent::getDownloadUrl($package);
+
+            $downloadUrl = str_replace('releases/download', '-/raw', $downloadUrl);
+
+            return $downloadUrl . '/builds/' . basename(Phar::running());
+
+        }
+    }

--- a/src/Components/Updater/Strategy/GitlabStrategy.php
+++ b/src/Components/Updater/Strategy/GitlabStrategy.php
@@ -1,7 +1,6 @@
 <?php
 
-
-    namespace LaravelZero\Framework\Components\Updater\Strategy;
+namespace LaravelZero\Framework\Components\Updater\Strategy;
 
     use Phar;
 
@@ -14,13 +13,14 @@
          *
          * @return string
          */
-        protected function getDownloadUrl(array $package): string{
+        protected function getDownloadUrl(array $package): string
+        {
 
             $downloadUrl = parent::getDownloadUrl($package);
 
             $downloadUrl = str_replace('releases/download', '-/raw', $downloadUrl);
 
-            return $downloadUrl . '/builds/' . basename(Phar::running());
+            return $downloadUrl.'/builds/'.basename(Phar::running());
 
         }
     }

--- a/src/Components/Updater/Strategy/GitlabStrategy.php
+++ b/src/Components/Updater/Strategy/GitlabStrategy.php
@@ -2,23 +2,23 @@
 
 namespace LaravelZero\Framework\Components\Updater\Strategy;
 
-    use Phar;
+use Phar;
 
-    class GitlabStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy implements StrategyInterface
+class GitlabStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy implements StrategyInterface
+{
+    /**
+     * Returns the Download Url.
+     *
+     * @param array $package
+     *
+     * @return string
+     */
+    protected function getDownloadUrl(array $package): string
     {
-        /**
-         * Returns the Download Url.
-         *
-         * @param array $package
-         *
-         * @return string
-         */
-        protected function getDownloadUrl(array $package): string
-        {
-            $downloadUrl = parent::getDownloadUrl($package);
+        $downloadUrl = parent::getDownloadUrl($package);
 
-            $downloadUrl = str_replace('releases/download', '-/raw', $downloadUrl);
+        $downloadUrl = str_replace('releases/download', '-/raw', $downloadUrl);
 
-            return $downloadUrl.'/builds/'.basename(Phar::running());
-        }
+        return $downloadUrl.'/builds/'.basename(Phar::running());
     }
+}

--- a/src/Components/Updater/Strategy/GitlabStrategy.php
+++ b/src/Components/Updater/Strategy/GitlabStrategy.php
@@ -15,12 +15,10 @@ namespace LaravelZero\Framework\Components\Updater\Strategy;
          */
         protected function getDownloadUrl(array $package): string
         {
-
             $downloadUrl = parent::getDownloadUrl($package);
 
             $downloadUrl = str_replace('releases/download', '-/raw', $downloadUrl);
 
             return $downloadUrl.'/builds/'.basename(Phar::running());
-
         }
     }


### PR DESCRIPTION
I noticed that the framework doesn't support self-update from GitLab by default

This PR is a simple (1 commit, 26 rows) implementation of a GitLab update strategy obtained by extending `\Humbug\SelfUpdate\Strategy\GithubStrategy`

the strategy just changes the download url build phase of the process, according to raw files different location between GitHub:

`https://github..com/[vendor]/[repository]/raw/[version]/builds/[app_name]`

and GitLab:

`https://gitlab.com/[vendor]/[repository]/-/raw/[version]/builds/[app_name]`


the result is a new strategy available:

- `LaravelZero\Framework\Components\Updater\Strategy\GitLabStrategy`