### PR TITLE
Fix support for Linux OS

### DIFF
--- a/src/Providers/GitVersion/GitVersionServiceProvider.php
+++ b/src/Providers/GitVersion/GitVersionServiceProvider.php
@@ -33,7 +33,7 @@ final class GitVersionServiceProvider extends ServiceProvider
             function (Application $app) {
                 $lastRevisionTag = '$(git rev-list --tags --max-count=1)';
 
-                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' || strtoupper(PHP_OS) === 'LINUX') {
                     $taskGetLastRevisionTag = ['git', 'rev-list', '--tags', '--max-count=1'];
 
                     $process = tap(new Process($taskGetLastRevisionTag, $app->basePath()))->run();

--- a/src/Providers/GitVersion/GitVersionServiceProvider.php
+++ b/src/Providers/GitVersion/GitVersionServiceProvider.php
@@ -31,22 +31,12 @@ final class GitVersionServiceProvider extends ServiceProvider
         $this->app->bind(
             'git.version',
             function (Application $app) {
-                $lastRevisionTag = '$(git rev-list --tags --max-count=1)';
+                $process = Process::fromShellCommandline(
+                    'git describe --tags --abbrev=0',
+                    $app->basePath()
+                );
 
-                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' || strtoupper(PHP_OS) === 'LINUX') {
-                    $taskGetLastRevisionTag = ['git', 'rev-list', '--tags', '--max-count=1'];
-
-                    $process = tap(new Process($taskGetLastRevisionTag, $app->basePath()))->run();
-
-                    $lastRevisionTag = trim($process->getOutput()) ?: 'unreleased';
-
-                    if ($lastRevisionTag === 'unreleased') {
-                        return 'unreleased';
-                    }
-                }
-                $task = ['git', 'describe', '--tags', $lastRevisionTag];
-
-                $process = tap(new Process($task, $app->basePath()))->run();
+                $process->run();
 
                 return trim($process->getOutput()) ?: 'unreleased';
             }


### PR DESCRIPTION
It seems that the git.version closure fails if launched from a Linux shell and the computed result is _unreleased_

![image](https://user-images.githubusercontent.com/8792274/91586946-6342c180-e956-11ea-9afe-a0928dbea5d4.png)


that's because the `$(git rev-list --tags --max-count=1)` command returns a newline character at the end of the string

i've tested it by writing a custom command with this:
```
$process = tap(new Process(['git', 'rev-list', '--tags', '--max-count=1'], app()->basePath()))->run();
dd($process->getOutput());
```
and will output this:

![image](https://user-images.githubusercontent.com/8792274/91586250-61c4c980-e955-11ea-8559-979c6920e000.png)

and this breaks the command `git describe --tags $(git rev-list --tags --max-count=1)` if executed through `Process->run()`


so I've changed the Windows fix in order to execute its code even in a linux environment:
```
if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN'  || strtoupper(PHP_OS) === 'LINUX')
```

this way the git.version is detected without any problem even in a Linux system:

![image](https://user-images.githubusercontent.com/8792274/91586659-fcbda380-e955-11ea-94d1-caf3fe830813.png)



**Additional Note**: what's the point of executing `git describe --tags $(git rev-list --tags --max-count=1)`  instead of two distinct steps? wouldn't result a cleaner code if we always make two separate calls to `Process->run()` and trimming the results instead of adding a check for OS name?
