### PR TITLE
feat: add abstract class for direct download updates

### DIFF
--- a/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
+++ b/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
@@ -20,7 +20,7 @@ abstract class AbstractDirectDownloadStrategy implements StrategyInterface
     {
         /** Switch remote request errors to HttpRequestExceptions */
         set_error_handler([$updater, 'throwHttpRequestException']);
-        $result = humbug_get_contents($this->getDownloadUrl());
+        $result = file_get_contents($this->getDownloadUrl());
         restore_error_handler();
         if (false === $result) {
             throw new HttpRequestException(sprintf(

--- a/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
+++ b/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
@@ -7,6 +7,14 @@ use Humbug\SelfUpdate\Exception\HttpRequestException;
 
 abstract class AbstractDirectDownloadStrategy implements StrategyInterface
 {
+    /** @var string */
+    protected $localVersion;
+
+    /** @var string */
+    protected $packageName;
+
+    abstract public function getDownloadUrl(): string;
+
     /** {@inheritdoc} */
     public function download(Updater $updater)
     {
@@ -30,11 +38,24 @@ abstract class AbstractDirectDownloadStrategy implements StrategyInterface
         return 'latest';
     }
 
+    public function setCurrentLocalVersion(string $version): void
+    {
+        $this->localVersion = $version;
+    }
+
     /** {@inheritdoc} */
     public function getCurrentLocalVersion(Updater $updater)
     {
         return $this->localVersion;
     }
 
-    abstract public function getDownloadUrl(): string;
+    public function setPackageName(string $name): void
+    {
+        $this->packageName = $name;
+    }
+
+    public function getPackageName(): string
+    {
+        return $this->packageName;
+    }
 }

--- a/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
+++ b/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace LaravelZero\Framework\Components\Updater\Strategy;
+
+use Humbug\SelfUpdate\Updater;
+use Humbug\SelfUpdate\Exception\HttpRequestException;
+
+abstract class AbstractDirectDownloadStrategy implements StrategyInterface
+{
+    /** {@inheritdoc} */
+    public function download(Updater $updater)
+    {
+        /** Switch remote request errors to HttpRequestExceptions */
+        set_error_handler(array($updater, 'throwHttpRequestException'));
+        $result = humbug_get_contents($this->getDownloadUrl());
+        restore_error_handler();
+        if (false === $result) {
+            throw new HttpRequestException(sprintf(
+                'Request to URL failed: %s',
+                $this->getDownloadUrl()
+            ));
+        }
+
+        file_put_contents($updater->getTempPharFile(), $result);
+    }
+
+    /** {@inheritdoc} */
+    public function getCurrentRemoteVersion(Updater $updater)
+    {
+        return 'latest';
+    }
+
+    /** {@inheritdoc} */
+    public function getCurrentLocalVersion(Updater $updater)
+    {
+        return $this->localVersion;
+    }
+
+    abstract public function getDownloadUrl(): string;
+}

--- a/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
+++ b/src/Components/Updater/Strategy/AbstractDirectDownloadStrategy.php
@@ -2,8 +2,8 @@
 
 namespace LaravelZero\Framework\Components\Updater\Strategy;
 
-use Humbug\SelfUpdate\Updater;
 use Humbug\SelfUpdate\Exception\HttpRequestException;
+use Humbug\SelfUpdate\Updater;
 
 abstract class AbstractDirectDownloadStrategy implements StrategyInterface
 {
@@ -19,7 +19,7 @@ abstract class AbstractDirectDownloadStrategy implements StrategyInterface
     public function download(Updater $updater)
     {
         /** Switch remote request errors to HttpRequestExceptions */
-        set_error_handler(array($updater, 'throwHttpRequestException'));
+        set_error_handler([$updater, 'throwHttpRequestException']);
         $result = humbug_get_contents($this->getDownloadUrl());
         restore_error_handler();
         if (false === $result) {


### PR DESCRIPTION
This class allows anyone to create their own direct download strategy for self-updates.

For example, if an app is downloaded from `https://example.com/example-cli-v12345.phar`, you could do:

```php
use LaravelZero\Framework\Components\Updater\Strategy\AbstractDirectDownloadStrategy;

class ExampleDirectDownloadStrategy extends AbstractDirectDownloadStrategy
{
    public function getDownloadUrl(): string
    {
        return 'https://example.com/example-cli-v12345.phar';
    }
}
```

Users can also override the `getCurrentRemoteVersion()` method if they want to, allowing them to download a PHAR based on their logic. For example, if the latest version was retrieved from a JSON file:

```php
use LaravelZero\Framework\Components\Updater\Strategy\AbstractDirectDownloadStrategy;

class ExampleDirectDownloadStrategy extends AbstractDirectDownloadStrategy
{
    /** {@inheritdoc} */
    public function getCurrentRemoteVersion(Updater $updater)
    {
        return Http::get('https://example.com/example-cli.json')->json()['latest-version'];
    }

    public function getDownloadUrl(): string
    {
        return 'https://example.com/example-cli-{$this->getCurrentRemoteVersion()}.phar';
    }
}
```