### PR TITLE
feat: add support for Box Dockerfile generation

### DIFF
--- a/tests/BuildCommandTest.php
+++ b/tests/BuildCommandTest.php
@@ -42,6 +42,27 @@ it('can build the application', function () {
     expect(File::exists(base_path('builds'.DIRECTORY_SEPARATOR.'version')))->toBeTrue();
 });
 
+it('can build the application with Dockerfile generation', function () {
+    $composerMock = $this->createMock(ComposerContract::class);
+    $this->app->instance(ComposerContract::class, $composerMock);
+
+    $output = new class() extends NullOutput {
+        public function section()
+        {
+            return new class() extends NullOutput {
+                public function clear()
+                {
+                }
+            };
+        }
+    };
+
+    Artisan::call('app:build', ['name' => 'version', '--no-interaction' => true, '--with-docker' => true], $output);
+
+    expect(File::exists(base_path('builds/version')))->toBeTrue();
+    expect(File::exists(base_path('builds/Dockerfile')))->toBeTrue();
+});
+
 it('reverts the config state after a build', function () {
     $composerMock = $this->createMock(ComposerContract::class);
     $this->app->instance(ComposerContract::class, $composerMock);


### PR DESCRIPTION
This feature allows passing a `--with-docker` flag to the `app:build` process and then this gets passed to Box and moved to the `builds/` directory when finished.

I've implemented it in two different ways with different commits in this PR:

- Method 1 (d798efb3f1e810f89a4a832329bc34329c050cbe) - The underlying Box binary used for Phar builds supports a `--with-docker` flag to generate a Dockerfile for distribution. Annoyingly it creates the `Dockerfile` in the working directory, which means it would in theory overwrite any that are already current in the root (e.g. if someone already creates a Docker image with the whole app contents in).

- Method 2 (b6f474b2362b003e2249875ec0671f3deab9819f) - The underlying Box binary also supports using `box docker builds/<application>` after the compilation has finished. Which is neater, and doesn't cause issues with an existing `Dockerfile`.

What are peoples' thoughts on this, and would it be a useful feature?