### PR TITLE
feat: Added support for migrating single file

### DIFF
--- a/src/Components/Database/Migrator.php
+++ b/src/Components/Database/Migrator.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace LaravelZero\Framework\Components\Database;
 
 use function collect;
+use Illuminate\Support\Str;
 use Illuminate\Database\Migrations\Migrator as BaseMigrator;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
@@ -35,10 +36,17 @@ class Migrator extends BaseMigrator
         return collect($paths)
             ->flatMap(
                 function ($path) {
-                    return collect(
-                        (new Finder)->in([$path])
+                    $finder = null;
+                    if (Str::endsWith($path, '.php')) {
+                        $finder = (new Finder)->in([dirname($path)])
                             ->files()
-                    )
+                            ->name(basename($path));
+                    } else {
+                        $finder = (new Finder)->in([$path])
+                            ->files();
+                    }
+
+                    return collect($finder)
                         ->map(
                             function (SplFileInfo $file) {
                                 return $file->getPathname();

--- a/src/Components/Database/Migrator.php
+++ b/src/Components/Database/Migrator.php
@@ -14,8 +14,8 @@ declare(strict_types=1);
 namespace LaravelZero\Framework\Components\Database;
 
 use function collect;
-use Illuminate\Support\Str;
 use Illuminate\Database\Migrations\Migrator as BaseMigrator;
+use Illuminate\Support\Str;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 

--- a/src/Components/Database/Migrator.php
+++ b/src/Components/Database/Migrator.php
@@ -36,7 +36,6 @@ class Migrator extends BaseMigrator
         return collect($paths)
             ->flatMap(
                 function ($path) {
-                    $finder = null;
                     if (Str::endsWith($path, '.php')) {
                         $finder = (new Finder)->in([dirname($path)])
                             ->files()


### PR DESCRIPTION
Laravel framework supports this and I have some situations I need to migrate only a single file instead of all migrations within the migrations folder. 

This can particularly when you have migrations within your build (phar) and migrations outside of the build.

In my case I need it to have a bit more control over migrations that are generated by a UI for example. I want to migrate a single migration at the time. If for some reason 1 migration fails I does not stall the entire process.