### PR TITLE
feat: update to allow extra Box options

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -107,10 +107,9 @@ final class BuildCommand extends Command
         }
 
         $boxBinary = windows_os() ? '.\box.bat' : './box';
-        $extraBoxOptions = $this->getExtraBoxOptions();
 
         $process = new Process(
-            [$boxBinary, 'compile', '--working-dir='.base_path(), '--config='.base_path('box.json')] + $extraBoxOptions,
+            [$boxBinary, 'compile', '--working-dir='.base_path(), '--config='.base_path('box.json')] + $this->getExtraBoxOptions(),
             dirname(__DIR__, 2).'/bin',
             null,
             null,

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -107,9 +107,10 @@ final class BuildCommand extends Command
         }
 
         $boxBinary = windows_os() ? '.\box.bat' : './box';
+        $extraBoxOptions = $this->getExtraBoxOptions();
 
         $process = new Process(
-            [$boxBinary, 'compile', '--working-dir='.base_path(), '--config='.base_path('box.json')],
+            [$boxBinary, 'compile', '--working-dir='.base_path(), '--config='.base_path('box.json')] + $extraBoxOptions,
             dirname(__DIR__, 2).'/bin',
             null,
             null,
@@ -236,6 +237,17 @@ final class BuildCommand extends Command
     private function supportsAsyncSignals(): bool
     {
         return extension_loaded('pcntl');
+    }
+
+    private function getExtraBoxOptions(): array
+    {
+        $extraBoxOptions = [];
+
+        if ($this->output->isDebug()) {
+            $extraBoxOptions[] = '--debug';
+        }
+
+        return $extraBoxOptions;
     }
 
     /**


### PR DESCRIPTION
This enables the `--debug` output, when using `-vvv` (debug) using the build command, as mentioned in https://github.com/laravel-zero/docs/pull/14#issuecomment-752073795 👍🏻