### PR TITLE
`BuildCommand::run()` does not return exit code

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -76,7 +76,7 @@ final class BuildCommand extends Command
      */
     public function run(InputInterface $input, OutputInterface $output)
     {
-        parent::run($input, $this->originalOutput = $output);
+        return parent::run($input, $this->originalOutput = $output);
     }
 
     /**


### PR DESCRIPTION
`BuildCommand::run()` should return the command exit code, but instead returns void. This violates the return type of the parent class.