### PR TITLE
ci: update to use stable dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,22 +5,11 @@ on: ['push', 'pull_request']
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.prerelease }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
         dependency-version: [prefer-lowest, prefer-stable]
-        prerelease: [false]
-        include:
-          - php: 8.0
-            os: ubuntu-latest
-            dependency-version: prefer-lowest
-            prerelease: true
-          - php: 8.0
-            os: ubuntu-latest
-            dependency-version: prefer-stable
-            prerelease: true
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
@@ -45,5 +34,4 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
-      continue-on-error: ${{ matrix.prerelease }}
       run: vendor/bin/pest --colors=always

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php }}
-        tools: composer:v2
+        tools: composer
         coverage: none
 
     - name: Setup Problem Matches
@@ -41,13 +41,8 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/php.json"
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-    - name: Install PHP 7 dependencies
+    - name: Install PHP dependencies
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
-      if: "matrix.php < 8"
-
-    - name: Install PHP 8 dependencies
-      run: composer update --${{ matrix.dependency-version }} --ignore-platform-req=php --no-interaction --no-progress --ansi
-      if: "matrix.php >= 8"
 
     - name: Unit Tests
       continue-on-error: ${{ matrix.prerelease }}


### PR DESCRIPTION
As PHP 8 is stable, and our dependencies have been updated to support it, it's now ok to test against stable dependencies without the need for the `--ignore-platform-req=php` flag.

I've also updated the matrix to fail the entire workflow suite if tests fail on PHP 8. 👍🏻