### PR TITLE
feat: update to use new PHAR Updater

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "laminas/laminas-text": "^2.8",
         "nunomaduro/laravel-console-dusk": "^1.8",
         "nunomaduro/laravel-console-menu": "^3.2",
-        "padraic/phar-updater": "^1.0.6",
+        "laravel-zero/phar-updater": "^1.0.6",
         "pestphp/pest": "^1.0",
         "phpstan/phpstan": "^0.12.65"
     },

--- a/src/Components/Updater/Installer.php
+++ b/src/Components/Updater/Installer.php
@@ -35,6 +35,6 @@ final class Installer extends AbstractInstaller
      */
     public function install(): void
     {
-        $this->require('padraic/phar-updater "^1.0.6"');
+        $this->require('laravel-zero/phar-updater "^1.0.6"');
     }
 }

--- a/tests/Components/UpdaterInstallTest.php
+++ b/tests/Components/UpdaterInstallTest.php
@@ -8,7 +8,7 @@ use LaravelZero\Framework\Contracts\Providers\ComposerContract;
 it('installs the required packages', function () {
     $composerMock = $this->createMock(ComposerContract::class);
 
-    $composerMock->expects($this->once())->method('require')->with('padraic/phar-updater "^1.0.6"');
+    $composerMock->expects($this->once())->method('require')->with('laravel-zero/phar-updater "^1.0.6"');
 
     $this->app->instance(ComposerContract::class, $composerMock);
 


### PR DESCRIPTION
This updates to use our fork of [Humbug's PHAR Updater](https://github.com/humbug/phar-updater), which will be kept up to date.

v1.0.6 is a release that matches (and replaces) v1.0.6 of Humbug's source. They are identical, except for the package name.

Future releases will start with v1.1.0, and [contains various changes](https://github.com/laravel-zero/phar-updater/compare/v1.0.6...laravel-zero:main) including code that wasn't released as a new version in Humbug's source, and also dropping support for PHP `<7.3` and adding tested support for PHP 8. All code is also now checked with PHPStan (at level 5) and StyleCI.