### PR TITLE
fix: add warning when INTL extension is missing

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -62,6 +62,12 @@ final class BuildCommand extends Command
      */
     public function handle()
     {
+        if (! extension_loaded('intl')) {
+            $this->error('The INTL extension is currently required for producing builds.');
+
+            return 1;
+        }
+
         if ($this->supportsAsyncSignals()) {
             $this->listenForSignals();
         }


### PR DESCRIPTION
Related to https://github.com/laravel-zero/laravel-zero/pull/337, we are waiting on a new Box binary following 3.12.0 (https://github.com/box-project/box/issues/530).

This way of implementing the changes still lets people use the framework, if they aren't using the `app:build` command. But will warn if the INTL extension isn't installed, rather than just throwing a hidden error.

Once the release comes for 3.12.0 or later, we'll update to that and then remove this.