### PR TITLE
chore: update minimum database version in component

### DIFF
--- a/src/Components/Database/Installer.php
+++ b/src/Components/Database/Installer.php
@@ -47,7 +47,7 @@ final class Installer extends AbstractInstaller
      */
     public function install(): void
     {
-        $this->require('illuminate/database "^8.0"');
+        $this->require('illuminate/database "^8.40"');
         $this->require('fakerphp/faker "^1.9.1"', true);
 
         $this->task(

--- a/tests/Components/DatabaseInstallTest.php
+++ b/tests/Components/DatabaseInstallTest.php
@@ -18,7 +18,7 @@ it('installs the required packages', function () {
     $composerMock->expects($this->exactly(2))
         ->method('require')
         ->withConsecutive(
-            ['illuminate/database "^8.0"', false],
+            ['illuminate/database "^8.40"', false],
             ['fakerphp/faker "^1.9.1"', true]
         );
 


### PR DESCRIPTION
This updates to use `illuminate/database:^8.40` which is a security patch.