### PR TITLE
Add `setPackageName` method to StrategyInterface

### DIFF
--- a/src/Components/Updater/Provider.php
+++ b/src/Components/Updater/Provider.php
@@ -17,6 +17,7 @@ use function class_exists;
 use Humbug\SelfUpdate\Updater as PharUpdater;
 use LaravelZero\Framework\Components\AbstractComponentProvider;
 use LaravelZero\Framework\Components\Updater\Strategy\GithubStrategy;
+use LaravelZero\Framework\Components\Updater\Strategy\StrategyInterface;
 use LaravelZero\Framework\Providers\Build\Build;
 
 /**
@@ -69,11 +70,14 @@ final class Provider extends AbstractComponentProvider
                 $name = $composer['name'];
 
                 $strategy = $this->app['config']->get('updater.strategy', GithubStrategy::class);
+
                 $updater->setStrategyObject(new $strategy);
 
-                $updater->getStrategy()->setPackageName($name);
+                if ($strategy instanceof StrategyInterface) {
+                    $updater->getStrategy()->setPackageName($name);
 
-                $updater->getStrategy()->setCurrentLocalVersion(config('app.version'));
+                    $updater->getStrategy()->setCurrentLocalVersion(config('app.version'));
+                }
 
                 return new Updater($updater);
             });

--- a/src/Components/Updater/Provider.php
+++ b/src/Components/Updater/Provider.php
@@ -73,7 +73,7 @@ final class Provider extends AbstractComponentProvider
 
                 $updater->setStrategyObject(new $strategy);
 
-                if ($strategy instanceof StrategyInterface) {
+                if ($updater->getStrategy() instanceof StrategyInterface) {
                     $updater->getStrategy()->setPackageName($name);
 
                     $updater->getStrategy()->setCurrentLocalVersion(config('app.version'));

--- a/src/Components/Updater/Strategy/StrategyInterface.php
+++ b/src/Components/Updater/Strategy/StrategyInterface.php
@@ -5,4 +5,6 @@ namespace LaravelZero\Framework\Components\Updater\Strategy;
 interface StrategyInterface extends \Humbug\SelfUpdate\Strategy\StrategyInterface
 {
     public function setPackageName($name);
+    
+    public function setCurrentLocalVersion($version);
 }

--- a/src/Components/Updater/Strategy/StrategyInterface.php
+++ b/src/Components/Updater/Strategy/StrategyInterface.php
@@ -4,4 +4,5 @@ namespace LaravelZero\Framework\Components\Updater\Strategy;
 
 interface StrategyInterface extends \Humbug\SelfUpdate\Strategy\StrategyInterface
 {
+    public function setPackageName($name);
 }

--- a/src/Components/Updater/Strategy/StrategyInterface.php
+++ b/src/Components/Updater/Strategy/StrategyInterface.php
@@ -5,6 +5,6 @@ namespace LaravelZero\Framework\Components\Updater\Strategy;
 interface StrategyInterface extends \Humbug\SelfUpdate\Strategy\StrategyInterface
 {
     public function setPackageName($name);
-    
+
     public function setCurrentLocalVersion($version);
 }


### PR DESCRIPTION
This is necessary to be added here as any custom Strategy used by `laravel-zero` will need this.
Otherwise the `Provider` will cause this to fail here https://github.com/laravel-zero/framework/blob/master/src/Components/Updater/Provider.php#L74

This fixes an issue I'm seeing here:
```shell
± |self-updater U:2 ?:1 ✗| → ./builds/site-tool self-update
[2021-06-17 00:25:10] production.ERROR: Call to undefined method App\UpdateStrategy\ShaStrategy::setPackageName() {"exception":"[object] (Error(code: 0): Call to undefined method App\\UpdateStrategy\\ShaStrategy::setPackageName() at phar:///Users/danpock/GitProjects/site-tool/builds/uptime-tool/vendor/laravel-zero/framework/src/Components/Updater/Provider.php:74)
[stacktrace]
```

It seems like since the strategy needs the laravel-zero interface to begin with then that interface might as well help enforce this requirement. I caught the error at runtime, but with this merged the next person might catch it in IDE linters.