### PR TITLE
feat: Add View Installer

### DIFF
--- a/src/Bootstrap/RegisterProviders.php
+++ b/src/Bootstrap/RegisterProviders.php
@@ -63,6 +63,7 @@ final class RegisterProviders implements BoostrapperContract
         Components\ConsoleDusk\Provider::class,
         Components\Menu\Provider::class,
         Components\Redis\Provider::class,
+        Components\View\Provider::class,
     ];
 
     /**

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -44,6 +44,7 @@ final class InstallCommand extends Command
         'queue' => Components\Queue\Installer::class,
         'redis' => Components\Redis\Installer::class,
         'self-update' => Components\Updater\Installer::class,
+        'view' => Components\View\Installer::class,
     ];
 
     /**

--- a/src/Components/View/Installer.php
+++ b/src/Components/View/Installer.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Zero.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace LaravelZero\Framework\Components\View;
+
+use Illuminate\Support\Facades\File;
+use LaravelZero\Framework\Components\AbstractInstaller;
+
+/**
+ * @internal
+ */
+final class Installer extends AbstractInstaller
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $name = 'install:view';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $description = 'View: Blade View Components';
+
+    /**
+     * The config file path.
+     */
+    private const CONFIG_FILE = __DIR__.DIRECTORY_SEPARATOR.'stubs'.DIRECTORY_SEPARATOR.'view.php';
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install(): void
+    {
+        $this->require('illuminate/view "^9.0"');
+
+        $this->task(
+            'Creating resources/views folder',
+            function () {
+                if (! File::exists(base_path('resources/views'))) {
+                    File::makeDirectory(base_path('resources/views'), 0755, true, true);
+
+                    return true;
+                }
+
+                return false;
+            }
+        );
+
+        $this->task(
+            'Creating default view configuration',
+            function () {
+                if (! File::exists(config_path('view.php'))) {
+                    return File::copy(
+                        static::CONFIG_FILE,
+                        $this->app->configPath('view.php')
+                    );
+                }
+
+                return false;
+            }
+        );
+
+        $this->task(
+            'Creating cache storage folder',
+            function () {
+                if (File::exists(base_path('storage/app/.gitignore') &&
+                    File::exists(base_path('storage/framework/views/.gitignore'))) {
+                    return false;
+                }
+
+                if (! File::exists(base_path('storage/app'))) {
+                    File::makeDirectory(base_path('storage/app'), 0755, true, true);
+                }
+
+                if (! File::exists(base_path('storage/app/.gitignore'))) {
+                    File::append(base_path('storage/app/.gitignore'), "*\n!.gitignore");
+                }
+
+                if (! File::exists(base_path('storage/framework/views'))) {
+                    File::makeDirectory(base_path('storage/framework/views'), 0755, true, true);
+                }
+
+                if (! File::exists(base_path('storage/framework/views/.gitignore'))) {
+                    File::append(base_path('storage/framework/views/.gitignore'), "*\n!.gitignore");
+                }
+
+                return true;
+            }
+        );
+    }
+}

--- a/src/Components/View/Installer.php
+++ b/src/Components/View/Installer.php
@@ -74,7 +74,7 @@ final class Installer extends AbstractInstaller
             'Creating cache storage folder',
             function () {
                 if (File::exists(base_path('storage/app/.gitignore') &&
-                    File::exists(base_path('storage/framework/views/.gitignore'))) {
+                    File::exists(base_path('storage/framework/views/.gitignore')))) {
                     return false;
                 }
 

--- a/src/Components/View/Provider.php
+++ b/src/Components/View/Provider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Zero.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace LaravelZero\Framework\Components\View;
+
+use function class_exists;
+use LaravelZero\Framework\Components\AbstractComponentProvider;
+
+/**
+ * @internal
+ */
+final class Provider extends AbstractComponentProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isAvailable(): bool
+    {
+        return class_exists(\Illuminate\View\ViewServiceProvider::class);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function register(): void
+    {
+        $this->app->register(\Illuminate\View\ViewServiceProvider::class);
+    }
+}

--- a/src/Components/View/stubs/view.php
+++ b/src/Components/View/stubs/view.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'paths' => [
+        resource_path('views'),
+    ],
+
+    'compiled' => env(
+        'VIEW_COMPILED_PATH',
+        realpath(storage_path('framework/views'))
+    ),
+];

--- a/tests/Application/config/view.php
+++ b/tests/Application/config/view.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'paths' => [
+        resource_path('views'),
+    ],
+
+    'compiled' => env(
+        'VIEW_COMPILED_PATH',
+        realpath(storage_path('framework/views'))
+    ),
+];

--- a/tests/Components/ViewInstallTest.php
+++ b/tests/Components/ViewInstallTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use LaravelZero\Framework\Contracts\Providers\ComposerContract;
+
+afterEach(function () {
+    File::deleteDirectory(base_path('resources'));
+    File::deleteDirectory(base_path('storage/app'));
+    File::deleteDirectory(base_path('storage/framework/views'));
+});
+
+it('installs the required packages', function () {
+    $composerMock = $this->createMock(ComposerContract::class);
+
+    $composerMock->expects($this->exactly(1))
+        ->method('require')
+        ->withConsecutive(
+            ['illuminate/view "^9.0"', false],
+        );
+
+    $this->app->instance(ComposerContract::class, $composerMock);
+
+    Artisan::call('app:install', ['component' => 'view']);
+});
+
+it('copies the required stubs', function () {
+    $composerMock = $this->createMock(ComposerContract::class);
+    $composerMock->method('require');
+    $this->app->instance(ComposerContract::class, $composerMock);
+
+    Artisan::call('app:install', ['component' => 'view']);
+
+    expect(File::exists(config_path('view.php')))->toBeTrue();
+    expect(File::exists(base_path('resources')))->toBeTrue();
+    expect(File::exists(base_path('resources/views')))->toBeTrue();
+    expect(File::exists(base_path('storage/app/.gitignore')))->toBeTrue();
+    expect(File::exists(base_path('storage/framework/views/.gitignore')))->toBeTrue();
+});


### PR DESCRIPTION
With the addition of Termwind as a default dependency, it makes sense to add support to the View Blade Engine.

So after the `php application app:install view` it will allow to render views and use with the **Termwind** `render` method.

Cheers!