### PR TITLE
fix: add missing `make:test` command

### DIFF
--- a/src/Commands/TestMakeCommand.php
+++ b/src/Commands/TestMakeCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Laravel Zero.
+ *
+ * (c) Nuno Maduro <enunomaduro@gmail.com>
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ */
+
+namespace LaravelZero\Framework\Commands;
+
+use Illuminate\Foundation\Console\TestMakeCommand as BaseTestMakeCommand;
+use function ucfirst;
+
+final class TestMakeCommand extends BaseTestMakeCommand
+{
+    /** {@inheritdoc} */
+    protected function getNameInput(): string
+    {
+        return ucfirst(parent::getNameInput());
+    }
+
+    /** {@inheritdoc} */
+    protected function getStub(): string
+    {
+        $suffix = $this->option('unit') ? '.unit.stub' : '.stub';
+
+        $relativePath = $this->option('pest')
+            ? '/stubs/pest'.$suffix
+            : '/stubs/test'.$suffix;
+
+        return file_exists($customPath = $this->laravel->basePath(trim($relativePath, '/')))
+            ? $customPath
+            : __DIR__.$relativePath;
+    }
+}

--- a/src/Commands/stubs/pest.stub
+++ b/src/Commands/stubs/pest.stub
@@ -1,0 +1,7 @@
+<?php
+
+test('inspiring command', function () {
+    $this->artisan('inspiring')
+      // ->expectsOutput('')
+         ->assertExitCode(0);
+});

--- a/src/Commands/stubs/pest.unit.stub
+++ b/src/Commands/stubs/pest.unit.stub
@@ -1,0 +1,5 @@
+<?php
+
+test('example', function () {
+    expect(true)->toBeTrue();
+});

--- a/src/Commands/stubs/test.stub
+++ b/src/Commands/stubs/test.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class {{ class }} extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function test_example()
+    {
+        $this->artisan('inspiring')
+          // ->expectsOutput('')
+             ->assertExitCode(0);
+    }
+}

--- a/src/Commands/stubs/test.unit.stub
+++ b/src/Commands/stubs/test.unit.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use PHPUnit\Framework\TestCase;
+
+class {{ class }} extends TestCase
+{
+    /**
+     * A basic unit test example.
+     *
+     * @return void
+     */
+    public function test_example()
+    {
+        $this->assertTrue(true);
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -19,7 +19,6 @@ use function defined;
 use function get_class;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Foundation\Console\Kernel as BaseKernel;
-use Illuminate\Foundation\Console\TestMakeCommand;
 use function in_array;
 use LaravelZero\Framework\Providers\CommandRecorder\CommandRecorderRepository;
 use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand;
@@ -40,7 +39,7 @@ class Kernel extends BaseKernel
         Commands\MakeCommand::class,
         Commands\InstallCommand::class,
         Commands\StubPublishCommand::class,
-        TestMakeCommand::class,
+        Commands\TestMakeCommand::class,
     ];
 
     /**

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -19,6 +19,7 @@ use function defined;
 use function get_class;
 use Illuminate\Console\Application as Artisan;
 use Illuminate\Foundation\Console\Kernel as BaseKernel;
+use Illuminate\Foundation\Console\TestMakeCommand;
 use function in_array;
 use LaravelZero\Framework\Providers\CommandRecorder\CommandRecorderRepository;
 use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand;
@@ -39,6 +40,7 @@ class Kernel extends BaseKernel
         Commands\MakeCommand::class,
         Commands\InstallCommand::class,
         Commands\StubPublishCommand::class,
+        TestMakeCommand::class,
     ];
 
     /**


### PR DESCRIPTION
Closes laravel-zero/laravel-zero#366