### PR TITLE
Change the seeders folder from 'seeds' to 'seeders'

### DIFF
--- a/src/Components/Database/Installer.php
+++ b/src/Components/Database/Installer.php
@@ -78,17 +78,17 @@ final class Installer extends AbstractInstaller
         );
 
         $this->task(
-            'Creating seeds folders and files',
+            'Creating seeders folders and files',
             function () {
-                if (File::exists($this->app->databasePath('seeds'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php'))) {
+                if (File::exists($this->app->databasePath('seeders'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php'))) {
                     return false;
                 }
 
-                File::makeDirectory($this->app->databasePath('seeds'), 0755, false, true);
+                File::makeDirectory($this->app->databasePath('seeders'), 0755, false, true);
 
                 File::copy(
                     self::SEEDER_FILE,
-                    $this->app->databasePath('seeds'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php')
+                    $this->app->databasePath('seeders'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php')
                 );
             }
         );

--- a/src/Components/Database/Provider.php
+++ b/src/Components/Database/Provider.php
@@ -90,8 +90,8 @@ class Provider extends AbstractComponentProvider
         $this->app->alias('db', \Illuminate\Database\ConnectionResolverInterface::class);
         $this->app->register(\Illuminate\Database\DatabaseServiceProvider::class);
 
-        if (File::exists($this->app->databasePath('seeds'))) {
-            collect(File::files($this->app->databasePath('seeds')))->each(
+        if (File::exists($this->app->databasePath('seeders'))) {
+            collect(File::files($this->app->databasePath('seeders')))->each(
                 function ($file) {
                     File::requireOnce($file);
                 }

--- a/tests/Components/DatabaseInstallTest.php
+++ b/tests/Components/DatabaseInstallTest.php
@@ -38,7 +38,7 @@ it('copies the required stubs', function () {
     expect(File::exists(database_path('database.sqlite')))->toBeTrue();
     expect(File::exists(database_path('migrations')))->toBeTrue();
     expect(File::exists(database_path('factories')))->toBeTrue();
-    expect(File::exists(database_path('seeds'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php')))->toBeTrue();
+    expect(File::exists(database_path('seeders'.DIRECTORY_SEPARATOR.'DatabaseSeeder.php')))->toBeTrue();
 });
 
 it('adds the required lines to the gitignore', function () {


### PR DESCRIPTION
I have compared the laravel and laravel-zero composer.json file, they seeders folder name is `seeders`, so I think we should fix it. Thank you.

https://github.com/laravel/laravel/blob/fa5e54a2ab6b1de8a4cef69b59bcfdecd07ab0cb/composer.json#L23-L29

https://github.com/laravel-zero/laravel-zero/blob/7a0c4a753272a5e06d0ab6128ce6add9960b04fe/composer.json#L28-L34
