### PR TITLE
Resolve skipped test

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -22,6 +22,7 @@ use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Throwable;
 
 final class BuildCommand extends Command implements SignalableCommandInterface
 {
@@ -93,9 +94,19 @@ final class BuildCommand extends Command implements SignalableCommandInterface
          * after compile all the code to a single file, we move the built file
          * to the builds folder with the correct permissions.
          */
-        $this->prepare()
-            ->compile($name)
-            ->clear();
+        $exception = null;
+
+        try {
+            $this->prepare()->compile($name);
+        } catch (Throwable $exception) {
+            //
+        }
+
+        $this->clear();
+
+        if ($exception !== null) {
+            throw $exception;
+        }
 
         $this->output->writeln(
             sprintf('    Compiled successfully: <fg=green>%s</>', $this->app->buildsPath($name))

--- a/tests/BuildCommandTest.php
+++ b/tests/BuildCommandTest.php
@@ -74,4 +74,4 @@ it('reverts the config state after a build', function () {
     expect($exception)->toBeInstanceOf(RuntimeException::class)
         ->and($exception->getMessage())->toEqual('Foo bar')
         ->and($contents)->toEqual(File::get(config_path('app.php')));
-})->skip('This test is currently broken (investigating)');
+});


### PR DESCRIPTION
Noticed the skipped test and could see the `BuildCommand::__destruct` (and/or clear) wasn't running and because of that the config file was not getting reverted correctly.

Not sure what the intention of the test initially was, but it looks like a test that ensures everything is reset back to the way it was even when an unexpected exception is thrown during the build. So I've updated the BuildCommand to follow that logic -- the test is now passing.

