### PR TITLE
Fixes build on windows

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -72,6 +72,10 @@ final class BuildCommand extends Command implements SignalableCommandInterface
     /** @return array<int, int> */
     public function getSubscribedSignals(): array
     {
+        if (! extension_loaded('pcntl')) {
+            return [];
+        }
+
         return [\SIGINT];
     }
 


### PR DESCRIPTION
This fixes `app:build` on windows after changes on [98db1f6](https://github.com/laravel-zero/framework/commit/98db1f626c19c36a2b3a0bc2551422cf18584ab5).

It opens a bug when stopping a build, as `clear()` won't be executed when there's no `pcntl` extension.

I've been checking and it seems `register_shutdown_function()` is useless as it doesn't run on SIGINT. I would suggest an approach like saving the original `app.php` and `box.json` with a suffix like `app.php.build`. We could recover then on the next build (I would left the app in production mode until that build tough, but I think that checking for those files on every app run would be overkill).