### PR TITLE
fix: issue of extenstion while using make command

### DIFF
--- a/src/Commands/MakeCommand.php
+++ b/src/Commands/MakeCommand.php
@@ -28,7 +28,7 @@ final class MakeCommand extends ConsoleMakeCommand
      */
     protected function getNameInput(): string
     {
-        return ucfirst(parent::getNameInput());
+        return ucfirst(trim(pathinfo(parent::getNameInput(), PATHINFO_FILENAME)));
     }
 
     /** {@inheritdoc} */

--- a/src/Commands/TestMakeCommand.php
+++ b/src/Commands/TestMakeCommand.php
@@ -21,7 +21,7 @@ final class TestMakeCommand extends BaseTestMakeCommand
     /** {@inheritdoc} */
     protected function getNameInput(): string
     {
-        return ucfirst(parent::getNameInput());
+        return ucfirst(trim(pathinfo(parent::getNameInput(), PATHINFO_FILENAME)));
     }
 
     /** {@inheritdoc} */


### PR DESCRIPTION
When using the make command, specifying the file extension (e.g., .php) creates an issue with PHP class files.

Description:

The current implementation of the make command creates command files with the specified extension. However, according to PHP naming conventions, class files should not include the file extension. This creates confusion and conflicts when working with frameworks or libraries that follow these conventions.

Proposed Solution:

To resolve this issue, I suggest modifying the make command to generate command files without the file extension. This adjustment ensures that the class file name matches the class name accurately, improving code organization and adherence to PHP best practices.

Thank you for considering this improvement. I'm available to provide any further information or assistance required to address this issue.

Screenshot:
https://i.ibb.co/LnKJkmq/Screenshot-2023-07-17-at-3-07-31-PM.png
https://i.ibb.co/dgyjVw3/Screenshot-2023-07-17-at-3-07-43-PM.png