### PR TITLE
Allow build command to work without pcntl

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -72,13 +72,17 @@ final class BuildCommand extends Command implements SignalableCommandInterface
     /** @return array<int, int> */
     public function getSubscribedSignals(): array
     {
-        return [\SIGINT];
+        if (defined('SIGINT')) {
+            return [\SIGINT];
+        }
+
+        return [];
     }
 
     /** {@inheritdoc} */
     public function handleSignal(int $signal): int|false
     {
-        if ($signal === \SIGINT) {
+        if (defined('SIGINT') && $signal === \SIGINT) {
             if (self::$config !== null) {
                 $this->clear();
             }


### PR DESCRIPTION
PR #365 added a way to intercept cancellation of the build command and do some cleanup. PR #473 updated this to use Symfony's built-in `SignalableCommandInterface`, but also broke the command on some platforms. That code assumes that the [`pcntl` extension](https://www.php.net/manual/en/book.pcntl.php) is present when it references the `SIGINT` constant. This prevents the command from being run in Docker containers with a minimal set of extensions installed and on Windows.

Following the example of https://github.com/spatie/laravel-backup/pull/1311, this PR checks for the presence of the `SIGINT` constant before attempting to use it.