### PR TITLE
fix: resolve Phar updater strategies

### DIFF
--- a/src/Components/Updater/Strategy/Concerns/UsesPharName.php
+++ b/src/Components/Updater/Strategy/Concerns/UsesPharName.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelZero\Framework\Components\Updater\Strategy\Concerns;
+
+trait UsesPharName
+{
+    private string $pharName;
+
+    public function setPharName($name): void
+    {
+        $this->pharName = $name;
+    }
+
+    public function getPharName(): string
+    {
+        return $this->pharName;
+    }
+}

--- a/src/Components/Updater/Strategy/GithubStrategy.php
+++ b/src/Components/Updater/Strategy/GithubStrategy.php
@@ -2,19 +2,18 @@
 
 namespace LaravelZero\Framework\Components\Updater\Strategy;
 
-use Phar;
+use LaravelZero\Framework\Components\Updater\Strategy\Concerns\UsesPharName;
 
 final class GithubStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy implements StrategyInterface
 {
-    /**
-     * Returns the Download Url.
-     */
+    use UsesPharName;
+
     protected function getDownloadUrl(array $package): string
     {
         $downloadUrl = parent::getDownloadUrl($package);
 
         $downloadUrl = str_replace('releases/download', 'raw', $downloadUrl);
 
-        return $downloadUrl.'/builds/'.basename(Phar::running());
+        return "{$downloadUrl}/builds/{$this->getPharName()}";
     }
 }

--- a/src/Components/Updater/Strategy/GitlabStrategy.php
+++ b/src/Components/Updater/Strategy/GitlabStrategy.php
@@ -2,19 +2,18 @@
 
 namespace LaravelZero\Framework\Components\Updater\Strategy;
 
-use Phar;
+use LaravelZero\Framework\Components\Updater\Strategy\Concerns\UsesPharName;
 
 class GitlabStrategy extends \Humbug\SelfUpdate\Strategy\GithubStrategy implements StrategyInterface
 {
-    /**
-     * Returns the Download Url.
-     */
+    use UsesPharName;
+
     protected function getDownloadUrl(array $package): string
     {
         $downloadUrl = parent::getDownloadUrl($package);
 
         $downloadUrl = str_replace('releases/download', '-/raw', $downloadUrl);
 
-        return $downloadUrl.'/builds/'.basename(Phar::running());
+        return "{$downloadUrl}/builds/{$this->getPharName()}";
     }
 }

--- a/src/Components/Updater/config/updater.php
+++ b/src/Components/Updater/config/updater.php
@@ -17,4 +17,19 @@ return [
 
     'strategy' => GithubStrategy::class,
 
+    /*
+    |--------------------------------------------------------------------------
+    | Self-updater Phar Name
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the name of the Phar file, as stored on GitHub or
+    | GitLab. This can be configured if the Phar name is different to the
+    | name of the Phar file running on the users' machine.
+    |
+    | Default: `null`
+    |
+    */
+
+    'phar_name' => null,
+
 ];


### PR DESCRIPTION
This depends on https://github.com/laravel-zero/framework/pull/480 to be merged first. 👍🏻 See https://github.com/laravel-zero/framework/commit/477b05c7a90e85160c3b70985e4a695f24646402 for the actual changes.

What does this do:
- Adds a new `updater.phar_name` config key, that, when set, will be used to set the name of the Phar file as stored on GitHub, GitLab, etc.
- Cleans up the `Updater/Provider`

This solution appears to work for resolving the mentioned issue, however it could probably do with some testing elsewhere to ensure it doesn't break any existing applications.

Closes https://github.com/laravel-zero/laravel-zero/issues/459