### PR TITLE
fix: resolve Laravel Prompts migration mismatch

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -175,7 +175,7 @@ final class BuildCommand extends Command implements SignalableCommandInterface
         $config = include $configFile;
 
         $config['env'] = 'production';
-        $version = $this->option('build-version') ?: text('Build version?', $config['version']);
+        $version = $this->option('build-version') ?: text('Build version?', default: $config['version']);
         $config['version'] = $version;
 
         $boxFile = $this->app->basePath('box.json');


### PR DESCRIPTION
This fixes an issue flagged up by Jess Archer where the placeholder has been filled instead of the default value.