### PR TITLE
Throw a more descriptive exception when the binary was not created

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -21,6 +21,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use RuntimeException;
 use Throwable;
 
 use function Laravel\Prompts\text;
@@ -162,7 +163,13 @@ final class BuildCommand extends Command implements SignalableCommandInterface
 
         $this->output->newLine();
 
-        File::move($this->app->basePath($this->getBinary()).'.phar', $this->app->buildsPath($name));
+        $pharPath = $this->app->basePath($this->getBinary()) . '.phar';
+        
+        if (! File::exists($pharPath)) {
+            throw new RuntimeException('Failed to compile the application.');
+        }
+
+        File::move($pharPath, $this->app->buildsPath($name));
 
         return $this;
     }


### PR DESCRIPTION
When the build command fails and a binary was not created, this results in an error like `rename(app.phar, builds/app): the system cannot find the file specified `. This is not very descriptive to the actual issue, so this PR adds a check to thrown an exception if the file was not created. This will make debugging easier.

See https://github.com/laravel-zero/laravel-zero/issues/461