### PR TITLE
Fix: Add SetRequestForConsole bootstrapper to the Kernel

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -63,6 +63,7 @@ class Kernel extends BaseKernel
         \LaravelZero\Framework\Bootstrap\LoadConfiguration::class,
         \Illuminate\Foundation\Bootstrap\HandleExceptions::class,
         \LaravelZero\Framework\Bootstrap\RegisterFacades::class,
+        \Illuminate\Foundation\Bootstrap\SetRequestForConsole::class,
         \LaravelZero\Framework\Bootstrap\RegisterProviders::class,
         \Illuminate\Foundation\Bootstrap\BootProviders::class,
     ];

--- a/tests/KernelTest.php
+++ b/tests/KernelTest.php
@@ -18,3 +18,7 @@ it('binds the output into the container', function () {
 it('binds the logger into the container', function () {
     expect(app('log'))->toBeInstanceOf(LoggerInterface::class);
 });
+
+it('binds a default request to the container', function () {
+    expect(app('request'))->toBeInstanceOf(\Illuminate\Http\Request::class);
+});


### PR DESCRIPTION
When using the Eloquent query builder pagination methods, like this :

```php
DB::table('users')->paginate(perPage: 15, page: 1);
```

Laravel tries to acces the `request` binding — and by doing so throws this Exception :

```
Illuminate\Contracts\Container\BindingResolutionException

Target class [request] does not exist.
```

To fix this error, we add this class to the bootstrappers list of the Kernel :

```php
\Illuminate\Foundation\Bootstrap\SetRequestForConsole::class
```

Ref https://github.com/laravel-zero/laravel-zero/issues/478