### PR TITLE
update console stub return types and docblocks

### DIFF
--- a/src/Commands/stubs/console.stub
+++ b/src/Commands/stubs/console.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace DummyNamespace;
+namespace {{ namespace }};
 
 use Illuminate\Console\Scheduling\Schedule;
 use LaravelZero\Framework\Commands\Command;
@@ -8,14 +8,14 @@ use LaravelZero\Framework\Commands\Command;
 class DummyClass extends Command
 {
     /**
-     * The signature of the command.
+     * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'dummy:command';
+    protected $signature = '{{ command }}';
 
     /**
-     * The description of the command.
+     * The console command description.
      *
      * @var string
      */

--- a/src/Commands/stubs/console.stub
+++ b/src/Commands/stubs/console.stub
@@ -23,19 +23,14 @@ class DummyClass extends Command
 
     /**
      * Execute the console command.
-     *
-     * @return mixed
      */
-    public function handle()
+    public function handle(): void
     {
         //
     }
 
     /**
      * Define the command's schedule.
-     *
-     * @param  \Illuminate\Console\Scheduling\Schedule  $schedule
-     * @return void
      */
     public function schedule(Schedule $schedule): void
     {

--- a/src/Commands/stubs/console.stub
+++ b/src/Commands/stubs/console.stub
@@ -24,7 +24,7 @@ class DummyClass extends Command
     /**
      * Execute the console command.
      */
-    public function handle(): void
+    public function handle()
     {
         //
     }


### PR DESCRIPTION
- add `void` return type
- remove unnecessary docblocks

syncs with a [docs change](https://github.com/laravel-zero/docs/commit/c402dd2ff5828361c4ef58f0ecede44923905bcb)