### PR TITLE
minor spelling and grammar adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,4 +45,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com) and this p
 
 ## [10.0.0 - 2023-02-16](https://github.com/laravel-zero/framework/releases/tag/v10.0.0)
 
-Check the upgrade guide in the [Official Laravel Zero Upgrade Documentation](https://laravel-zero.com/docs/upgrade#upgrade-10.0.0). Also you can see some changes in the [Official Laravel Upgrade Documentation](https://laravel.com/docs/10.x/upgrade).
+Check the upgrade guide in the [Official Laravel Zero Upgrade Documentation](https://laravel-zero.com/docs/upgrade#upgrade-10.0.0). Also, you can see some changes in the [Official Laravel Upgrade Documentation](https://laravel.com/docs/10.x/upgrade).

--- a/src/Application.php
+++ b/src/Application.php
@@ -111,7 +111,7 @@ class Application extends BaseApplication
     }
 
     /**
-     * Throw an Console Exception with the given data unless the given condition is true.
+     * Throw a Console Exception with the given data unless the given condition is true.
      */
     public function abort($code, $message = '', array $headers = []): void
     {

--- a/src/Bootstrap/BuildLoadEnvironmentVariables.php
+++ b/src/Bootstrap/BuildLoadEnvironmentVariables.php
@@ -42,7 +42,7 @@ final class BuildLoadEnvironmentVariables implements BoostrapperContract
     public function bootstrap(Application $app): void
     {
         /*
-         * Override environment variables with the environment file along side the Phar file.
+         * Override environment variables with the environment file alongside the Phar file.
          */
         if ($this->build->shouldUseEnvironmentFile()) {
             Dotenv::createMutable($this->build->getDirectoryPath(), $this->build->environmentFile())->load();


### PR DESCRIPTION
- "alongside" is one word
- use "a" instead of "an" when the following word does not have a vowel sound
- If you use also as a conjunctive adverb at the beginning of the second clause of a compound sentence, you use a comma.