### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/laravel-zero/framework/actions"><img src="https://img.shields.io/github/actions/workflow/status/laravel-zero/framework/tests.yml?branch=master" alt="Build Status"></a>
-  <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/dt/laravel-zero/framework.svg" alt="Total Downloads"></a>
-  <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/v/laravel-zero/framework.svg?label=stable" alt="Latest Stable Version"></a>
-  <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/l/laravel-zero/framework.svg" alt="License"></a>
+  <a href="https://github.com/laravel-zero/framework/actions"><img src="https://img.shields.io/github/actions/workflow/status/laravel-zero/framework/tests.yml?branch=master" alt="Build Status" /></a>
+  <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/dt/laravel-zero/framework.svg" alt="Total Downloads" /></a>
+  <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/v/laravel-zero/framework.svg?label=stable" alt="Latest Stable Version" /></a>
+  <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/l/laravel-zero/framework.svg" alt="License" /></a>
 </p>
 
 Laravel Zero was created by [Nuno Maduro](https://github.com/nunomaduro) and [Owen Voke](https://github.com/owenvoke), and is a micro-framework that provides an elegant starting point for your console application. It is an **unofficial** and customized version of Laravel optimized for building command-line applications.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<p align="center">
-    <img title="Laravel Zero" height="100" src="https://raw.githubusercontent.com/laravel-zero/docs/master/images/logo/laravel-zero-readme.png" />
+<p style="text-align: center; ">
+    <img title="Laravel Zero" height="100" src="https://raw.githubusercontent.com/laravel-zero/docs/master/images/logo/laravel-zero-readme.png" alt="Laravel Zero Logo" />
 </p>
 
-<p align="center">
-  <a href="https://github.com/laravel-zero/framework/actions"><img src="https://img.shields.io/github/actions/workflow/status/laravel-zero/framework/tests.yml?branch=master" alt="Build Status"></img></a>
+<p style="text-align: center; ">
+  <a href="https://github.com/laravel-zero/framework/actions"><img src="https://img.shields.io/github/actions/workflow/status/laravel-zero/framework/tests.yml?branch=master" alt="Build Status"></a>
   <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/dt/laravel-zero/framework.svg" alt="Total Downloads"></a>
   <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/v/laravel-zero/framework.svg?label=stable" alt="Latest Stable Version"></a>
   <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/l/laravel-zero/framework.svg" alt="License"></a>
 </p>
 
-<h4> <center>This is a <bold>community project</bold> and not an official Laravel one </center></h4>
+<h4 style="text-align: center; ">This is a community project and not an official Laravel one</h4>
 
 Laravel Zero was created by [Nuno Maduro](https://github.com/nunomaduro) and [Owen Voke](https://github.com/owenvoke), and is a micro-framework that provides an elegant starting point for your console application. It is an **unofficial** and customized version of Laravel optimized for building command-line applications.
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
-<p style="text-align: center; ">
+<p align="center">
     <img title="Laravel Zero" height="100" src="https://raw.githubusercontent.com/laravel-zero/docs/master/images/logo/laravel-zero-readme.png" alt="Laravel Zero Logo" />
 </p>
 
-<p style="text-align: center; ">
+<p align="center">
   <a href="https://github.com/laravel-zero/framework/actions"><img src="https://img.shields.io/github/actions/workflow/status/laravel-zero/framework/tests.yml?branch=master" alt="Build Status"></a>
   <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/dt/laravel-zero/framework.svg" alt="Total Downloads"></a>
   <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/v/laravel-zero/framework.svg?label=stable" alt="Latest Stable Version"></a>
   <a href="https://packagist.org/packages/laravel-zero/framework"><img src="https://img.shields.io/packagist/l/laravel-zero/framework.svg" alt="License"></a>
 </p>
-
-<h4 style="text-align: center; ">This is a community project and not an official Laravel one</h4>
 
 Laravel Zero was created by [Nuno Maduro](https://github.com/nunomaduro) and [Owen Voke](https://github.com/owenvoke), and is a micro-framework that provides an elegant starting point for your console application. It is an **unofficial** and customized version of Laravel optimized for building command-line applications.
 


### PR DESCRIPTION
- `align` is an obsolete HTML5 attribute. replace with CSS styling.
- add an `alt` attribute to the `<img>` tag for accessibility.
- remove redundant `</img>` closing tag.
- the `<center>` tag is not supported in HTML5. replace with CSS styling.
- the `<bold>` tag does not exist. The `<h4>` receives bolding anyway, so the whole line is bolded.