### PR TITLE
Omit default values for suffix in phpunit.xml

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -6,16 +6,16 @@
 >
     <testsuites>
         <testsuite name="Tests">
-            <directory suffix="Test.php">./tests</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory suffix=".php">./src</directory>
+            <directory>./src</directory>
         </include>
         <exclude>
-            <directory suffix=".php">./src/Components/Database/stubs</directory>
-            <directory suffix=".php">./src/Components/Log/stubs</directory>
+            <directory>./src/Components/Database/stubs</directory>
+            <directory>./src/Components/Log/stubs</directory>
         </exclude>
     </source>
 </phpunit>


### PR DESCRIPTION
The values specified for `suffix` are their respective defaults and can be omitted.

Follows from https://github.com/laravel/laravel/pull/6210