### PR TITLE
fix: unable to remove lazy loaded commands

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -205,8 +205,17 @@ class Kernel extends BaseKernel
          * command class.
          */
         Artisan::starting(
-            function ($artisan) use ($commands) {
+            function ($artisan) use ($commands, $toRemoveCommands) {
                 $artisan->resolveCommands($commands->toArray());
+
+                $reflectionClass = new ReflectionClass(Artisan::class);
+                $property = $reflectionClass->getProperty('commandMap');
+                $commandMap = collect($property->getValue($artisan))
+                    ->filter(
+                        fn ($command) => ! in_array($command, $toRemoveCommands, true)
+                    )
+                    ->toArray();
+                $property->setValue($artisan, $commandMap);
 
                 $artisan->setContainerCommandLoader();
             }


### PR DESCRIPTION
It appears the fix from https://github.com/laravel-zero/laravel-zero/issues/416 is not working on v10.

Currently, adding `Illuminate\Database\Console\WipeCommand::class` to `'remove'` commands config does nothing.  With this PR applied, the `db:wipe` command is successfully disabled.