### PR TITLE
Remove extra newline from source code

### DIFF
--- a/src/Bootstrap/LoadEnvironmentVariables.php
+++ b/src/Bootstrap/LoadEnvironmentVariables.php
@@ -31,7 +31,6 @@ final class LoadEnvironmentVariables implements BootstrapperContract
     public function bootstrap(Application $app): void
     {
         if (class_exists(Dotenv::class)) {
-
             if (file_exists($app->environmentFilePath())) {
                 $app->make(BaseLoadEnvironmentVariables::class)->bootstrap($app);
             }


### PR DESCRIPTION
Fixes code style. Also, only one of two used functions are imported, should we import `file_exists` as well?