### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,55 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "7.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "8.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "9.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "10.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "11.x"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -16,10 +16,10 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: 8.2
           extensions: zip
@@ -27,7 +27,7 @@ jobs:
           coverage: none
 
       - name: Install PHP dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3
         with:
           dependency-versions: highest
           composer-options: "--prefer-dist"
@@ -43,10 +43,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
       with:
         php-version: 8.2
         extensions: zip
@@ -54,7 +54,7 @@ jobs:
         coverage: none
 
     - name: Install PHP dependencies
-      uses: ramsey/composer-install@v3
+      uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3
       with:
         dependency-versions: highest
         composer-options: "--prefer-dist"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
       with:
         php-version: ${{ matrix.php }}
         extensions: zip
@@ -32,7 +32,7 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
     - name: Install PHP dependencies
-      uses: ramsey/composer-install@v3
+      uses: ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f # v3
       with:
         dependency-versions: ${{ matrix.dependency-version }}
         composer-options: "--prefer-dist"


### PR DESCRIPTION
Pins every `uses:` reference in this repo's GitHub Actions workflows to a
commit SHA, preserving the original tag as an inline comment so Dependabot can
keep bumping it.

Rewrites:

  - `actions/checkout@v5` → `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (in `.github/workflows/static.yml`)
  - `shivammathur/setup-php@v2` → `shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f` (in `.github/workflows/static.yml`)
  - `ramsey/composer-install@v3` → `ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f` (in `.github/workflows/static.yml`)
  - `actions/checkout@v5` → `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (in `.github/workflows/static.yml`)
  - `shivammathur/setup-php@v2` → `shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f` (in `.github/workflows/static.yml`)
  - `ramsey/composer-install@v3` → `ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f` (in `.github/workflows/static.yml`)
  - `actions/checkout@v5` → `actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd` (in `.github/workflows/tests.yml`)
  - `shivammathur/setup-php@v2` → `shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f` (in `.github/workflows/tests.yml`)
  - `ramsey/composer-install@v3` → `ramsey/composer-install@a8d0d959dab41457692a5e2041bd9b757a119e3f` (in `.github/workflows/tests.yml`)
  - added `.github/dependabot.yml` (weekly grouped github-actions updates)

This mitigates supply-chain risk from compromised action tag/branch refs and
makes future Dependabot PRs update the SHA in place (rather than only bumping
tags).