### PR TITLE
[11.x] Fix PHP 8.5 deprecation warning for `PDO::MYSQL_ATTR_SSL_CA`

### DIFF
--- a/src/Components/Database/stubs/database.php
+++ b/src/Components/Database/stubs/database.php
@@ -55,7 +55,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -75,7 +75,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
### Description

This PR patches a deprecation warning triggered when using PHP 8.5 with Laravel Zero 11.x. 

I understand that Laravel Zero 11 may not be officially supported anymore, but since a lot of projects are still running it, this minor patch would provide a lot of value with minimal downside.

See tie in PR https://github.com/laravel-zero/foundation/pull/133

**Background:**
In PHP 8.5, the global `PDO::MYSQL_ATTR_SSL_CA` constant was deprecated in favor of the namespaced `Pdo\Mysql::ATTR_SSL_CA`. However, because Laravel Zero 11.x must maintain compatibility with PHP 8.2 and 8.3 (where the `Pdo\Mysql` class does not exist), we cannot simply swap the constant without causing a fatal error in older environments.

**The Fix:**
This PR updates the MySQL and MariaDB connection configurations to use a conditional check:
`(defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA)`

This dynamically applies the new constant for users on PHP 8.5+, while safely falling back to the legacy constant for users on PHP 8.2 - 8.4, completely resolving the deprecation notice without introducing breaking changes.

### Related Issues
* Backports the concept from the v12 fix discussed in: laravel-zero/laravel-zero#519
* Resolves downstream framework issues, such as: hydephp/hyde#322

### Checklist
- [x] I have tested this change locally to ensure compatibility across PHP versions.
- [x] The code follows the repository's coding standards.